### PR TITLE
autotools: improve man page installation, generate localized man pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ data/pkg/arch/pkg
 data/pkg/arch/src
 data/pkg/desktop/com.gexperts.Tilix.desktop
 data/appdata/com.gexperts.Tilix.appdata.xml
+data/man/man
 *.pkg.tar.xz
 *~
 *.xdgapp

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,10 +21,8 @@ dist_nautilusext_DATA = $(srcdir)/data/nautilus/open-tilix.py
 scriptsdir = $(datadir)/tilix/scripts/
 dist_scripts_DATA = $(srcdir)/data/scripts/tilix_int.sh
 
-man1_MANS = $(srcdir)/data/man/tilix
-
 EXTRA_DIST = LICENSE README.md
 CLEANFILES = tilix.o
 
-SUBDIRS = data/appdata data/icons data/pkg/desktop data/resources po
+SUBDIRS = data/appdata data/icons data/pkg/desktop data/resources data/man po
 ACLOCAL_AMFLAGS = -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@ AC_PATH_PROG([GLIB_COMPILE_RES], [glib-compile-resources])
 PKG_PROG_PKG_CONFIG
 AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.19.7])
+AC_PATH_PROG([PO4A_TRANS], [po4a-translate])
 
 DC_SUFFIX=
 case $(basename $DC) in
@@ -45,5 +46,5 @@ PKG_CHECK_MODULES([GTKD], [gtkd-3$DC_SUFFIX >= 3.3.0 vted-3$DC_SUFFIX >= 3.3.0],
 PKG_CHECK_MODULES([X11], [x11])
 
 AM_INIT_AUTOMAKE([1.15 foreign])
-AC_CONFIG_FILES([Makefile data/appdata/Makefile data/icons/Makefile data/pkg/desktop/Makefile data/resources/Makefile po/Makefile.in])
+AC_CONFIG_FILES([Makefile data/appdata/Makefile data/icons/Makefile data/pkg/desktop/Makefile data/resources/Makefile data/man/Makefile po/Makefile.in])
 AC_OUTPUT

--- a/data/man/Makefile.am
+++ b/data/man/Makefile.am
@@ -1,0 +1,17 @@
+mansdir = $(datadir)
+manfile = $(builddir)/man/man1/tilix.1.gz
+mansfiles = $(shell find $(srcdir)/po -name '*.man.po' | sed "s_$(srcdir)/po/\(.*\)\.man\.po_$(builddir)/man/\1/man1/tilix.1.gz_g")
+nobase_dist_mans_DATA = $(manfile) $(mansfiles)
+
+$(manfile): $(srcdir)/tilix
+	$(INSTALL) -d $(@D); \
+	$(INSTALL) $< $(@D)/tilix.1; \
+	gzip -f $(@D)/tilix.1
+
+$(builddir)/man/%/man1/tilix.1.gz: $(srcdir)/po/%.man.po
+	$(INSTALL) -d "$(builddir)"/man/$(*F)/man1; \
+	$(PO4A_TRANS) -k 0 -f man -m "$(srcdir)"/tilix -p $< -l "$(builddir)"/man/$(*F)/man1/tilix.1; \
+	gzip -f "$(builddir)"/man/$(*F)/man1/tilix.1; 
+
+EXTRA_DIST = $(srcdir)/tilix $(srcdir)/po/*.man.po 
+CLEANFILES = $(manfile) $(mansfiles)


### PR DESCRIPTION
This adds a new build dependency for autotools builds (`po4a-translate`), required for localizing man pages.

EDIT: Works For Me, so more testing would be nice.
EDIT2: This should fix #842 