### PR TITLE
Don't call query_info which might block

### DIFF
--- a/data/nautilus/open-tilix.py
+++ b/data/nautilus/open-tilix.py
@@ -110,11 +110,7 @@ class OpenTilixExtension(GObject.GObject, Nautilus.MenuProvider):
                 item.connect('activate', self.menu_activate_cb, file)
                 items.append(item)
 
-            gfile = Gio.File.new_for_uri(file.get_uri())
-            info = gfile.query_info(
-                "standard::*", Gio.FileQueryInfoFlags.NONE, None)
-            # Get UTF-8 version of basename
-            filename = info.get_attribute_as_string("standard::name")
+            filename = file.get_name()
 
             item = Nautilus.MenuItem(name='NautilusPython::openterminal_file_item',
                                      label=_(u'Open In Tilix'),


### PR DESCRIPTION
g_file_query_info is a sync API that will do IO and potentially
block if the network connection is slow (or dropped). If that
call blocks, it will freeze nautilus since the extension is called
from the main thread. Since we only use the resulting information
for the filename add a tooltip use the get_name() provided by
nautilus itself instead.