### PR TITLE
Fix linker flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ tilix.o: $(tilix_SOURCES)
 	$(DC) $(DCFLAGS) $(GTKD_CFLAGS) $(GTKD_LIBS) -c $^ -of$@
 # libx11 is a C library, so we need to precede with -L
 tilix$(EXEEXT): tilix.o
-	$(DC) $(GTKD_LIBS) -L$(X11_LIBS) $^ -of$@
+	$(DC) $(GTKD_LIBS) $(addprefix -L,$(X11_LIBS)) $^ -of$@
 
 gschemasdir = $(datadir)/glib-2.0/schemas/
 dist_gschemas_DATA = $(srcdir)/data/gsettings/com.gexperts.Tilix.gschema.xml


### PR DESCRIPTION
Every linker flag for libx11 needs to be preceded with `-L` . However, only the first flag was actually done so, causing build failures when pkg-config returned multiple linker flags for libx11.

```
make[1]: Entering directory '/tmp/nix-build-tilix-1.5.6.drv-0/tilix-1.5.6'
/nix/store/jzv9nh5k5pmcimmmlyk3grcjklbkimwx-dmd-2.070.2/bin/dmd -O -I/nix/store/5lrssnllkm9c89wbx5k8xw51ilrsrhnl-gtkd-3.6.1/include/d/gtkd-3/ -L-lvted-3 -L-L/nix/store/5lrssnllkm9c89wbx5k8xw51ilrsrhnl-gtkd-3.6.1/lib// -L-lgtkd-3 -L-ldl -c source/app.d source/gx/gtk/actions.d source/gx/gtk/cairo.d source/gx/gtk/clipboard.d source/gx/gtk/dialog.d source/gx/gtk/resource.d source/gx/gtk/settings.d source/gx/gtk/threads.d source/gx/gtk/util.d source/gx/gtk/vte.d source/gx/gtk/x11.d source/gx/i18n/l10n.d source/gx/tilix/application.d source/gx/tilix/appwindow.d source/gx/tilix/bookmark/bmchooser.d source/gx/tilix/bookmark/bmeditor.d source/gx/tilix/bookmark/bmtreeview.d source/gx/tilix/bookmark/manager.d source/gx/tilix/closedialog.d source/gx/tilix/cmdparams.d source/gx/tilix/colorschemes.d source/gx/tilix/common.d source/gx/tilix/constants.d source/gx/tilix/customtitle.d source/gx/tilix/encoding.d source/gx/tilix/prefeditor/advdialog.d source/gx/tilix/prefeditor/bookmarkeditor.d source/gx/tilix/prefeditor/common.d source/gx/tilix/prefeditor/prefdialog.d source/gx/tilix/prefeditor/profileeditor.d source/gx/tilix/prefeditor/titleeditor.d source/gx/tilix/preferences.d source/gx/tilix/session.d source/gx/tilix/sessionswitcher.d source/gx/tilix/shortcuts.d source/gx/tilix/sidebar.d source/gx/tilix/terminal/actions.d source/gx/tilix/terminal/advpaste.d source/gx/tilix/terminal/exvte.d source/gx/tilix/terminal/layout.d source/gx/tilix/terminal/password.d source/gx/tilix/terminal/regex.d source/gx/tilix/terminal/search.d source/gx/tilix/terminal/terminal.d source/gx/tilix/terminal/util.d source/gx/util/array.d source/gx/util/path.d source/gx/util/string.d source/secret/Collection.d source/secret/Item.d source/secret/Prompt.d source/secret/Schema.d source/secret/SchemaAttribute.d source/secret/Secret.d source/secret/Service.d source/secret/Value.d source/secretc/secret.d source/secretc/secrettypes.d source/x11/X.d source/x11/Xlib.d -oftilix.o
/nix/store/jzv9nh5k5pmcimmmlyk3grcjklbkimwx-dmd-2.070.2/bin/dmd -L-lvted-3 -L-L/nix/store/5lrssnllkm9c89wbx5k8xw51ilrsrhnl-gtkd-3.6.1/lib// -L-lgtkd-3 -L-ldl -L-L/nix/store/cxa71yq4q45kqrm4gsn21lqazmny8xjx-libX11-1.6.5/lib -lX11 tilix.o -oftilix
Error: unrecognized switch '-lX11'
make[1]: *** [Makefile:1037: tilix] Error 1
make[1]: Leaving directory '/tmp/nix-build-tilix-1.5.6.drv-0/tilix-1.5.6'
make: *** [Makefile:606: all-recursive] Error 1
```