### PR TITLE
autotools: Don't override DCFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AC_ARG_VAR([DCFLAGS], [flags for dmd compiler])
 
 # Full optimization flags
 #DCFLAGS='-O -inline -release -version=StdLoggerDisableTrace'
-DCFLAGS='-O'
+: ${DCFLAGS='-O'}
 AC_SUBST([DCFLAGS])
 
 # Checks for programs.


### PR DESCRIPTION
The configure.ac sets DCFLAGS, which means that it's not possible to set custom DCFLAGS when building the program.  This changes configure.ac so that it will only set default DCFLAGS if it has not already been set externally.

Tilix in Debian was accidentally built with debugging enabled because of this.  See https://bugs.debian.org/863491.