### PR TITLE
Clean the open-tilix.py code

### DIFF
--- a/data/nautilus/open-tilix.py
+++ b/data/nautilus/open-tilix.py
@@ -22,7 +22,7 @@ textdomain("tilix")
 _ = gettext
 
 
-def open_terminl_in_file(filename):
+def open_terminal_in_file(filename):
   if filename:
     call('{0} -w "{1}" &'.format(TERMINAL, filename), shell=True)
   else:
@@ -55,7 +55,7 @@ class OpenTilixShortcutProvider(GObject.GObject,
 
   def _open_terminal(self, *args):
     filename = unquote(self._uri[7:])
-    open_terminl_in_file(filename)
+    open_terminal_in_file(filename)
 
   def get_widget(self, uri, window):
     self._uri = uri
@@ -85,7 +85,7 @@ class OpenTilixExtension(GObject.GObject, Nautilus.MenuProvider):
       call('{0} -e "{1}" &'.format(TERMINAL, value), shell=True)
     else:
       filename = Gio.File.new_for_uri(file_.get_uri()).get_path()
-      open_terminl_in_file(filename)
+      open_terminal_in_file(filename)
 
   def _menu_activate_cb(self, menu, file_):
     self._open_terminal(file_)

--- a/data/nautilus/open-tilix.py
+++ b/data/nautilus/open-tilix.py
@@ -1,137 +1,138 @@
 # -*- coding: UTF-8 -*-
-
 # This example is contributed by Martin Enlund
 # Example modified for Tilix
 # Shortcuts Provider was inspired by captain nemo extension
-import gettext
-from urllib import unquote
 
+from gettext import gettext, textdomain
 from subprocess import PIPE, call
+from urllib import unquote
 from urlparse import urlparse
-gettext.textdomain("tilix")
-_ = gettext.gettext
 
 from gi import require_version
-
 require_version('Gtk', '3.0')
 require_version('Nautilus', '3.0')
+from gi.repository import Gio, GObject, Gtk, Nautilus
 
-from gi.repository import GObject, Gdk, Gio, Gtk, Nautilus
 
 TERMINAL = "tilix"
+TILIX_KEYBINDINGS = "com.gexperts.Tilix.Keybindings"
+GSETTINGS_OPEN_TERMINAL = "nautilus-open"
+REMOTE_URI_SCHEME = ['ftp', 'sftp']
+textdomain("tilix")
+_ = gettext
 
 
 def open_terminl_in_file(filename):
-    if filename:
-        call('{0} -w "{1}" &'.format(TERMINAL, filename), shell=True)
-    else:
-        call("{0} &".format(TERMINAL), shell=True)
+  if filename:
+    call('{0} -w "{1}" &'.format(TERMINAL, filename), shell=True)
+  else:
+    call("{0} &".format(TERMINAL), shell=True)
 
 
-class OpenTilixShortcutProvider(GObject.GObject, Nautilus.LocationWidgetProvider):
+class OpenTilixShortcutProvider(GObject.GObject,
+                                Nautilus.LocationWidgetProvider):
 
-    def __init__(self):
-        self.accel_group = Gtk.AccelGroup()
-        source = Gio.SettingsSchemaSource.get_default()
-        if source.lookup("com.gexperts.Tilix.Keybindings", True):
-            self.gsettings = Gio.Settings.new(
-                "com.gexperts.Tilix.Keybindings")
-            self.gsettings.connect("changed", self.bind_shortcut)
-            self._create_accel_group()
-        self.window = None
-        self.uri = None
+  def __init__(self):
+    source = Gio.SettingsSchemaSource.get_default()
+    if source.lookup(TILIX_KEYBINDINGS, True):
+      self._gsettings = Gio.Settings.new(TILIX_KEYBINDINGS)
+      self._gsettings.connect("changed", self._bind_shortcut)
+      self._create_accel_group()
+    self._window = None
+    self._uri = None
 
-    def _create_accel_group(self):
-        shortcut = self.gsettings.get_string("nautilus-open")
-        key, mod = Gtk.accelerator_parse(shortcut)
-        self.accel_group.connect(
-            key, mod, Gtk.AccelFlags.VISIBLE, self._open_terminal)
+  def _create_accel_group(self):
+    self._accel_group = Gtk.AccelGroup()
+    shortcut = self._gsettings.get_string(GSETTINGS_OPEN_TERMINAL)
+    key, mod = Gtk.accelerator_parse(shortcut)
+    self._accel_group.connect(key, mod, Gtk.AccelFlags.VISIBLE,
+                              self._open_terminal)
 
-    def bind_shortcut(self, gsettings, key):
-        if key == "nautilus-open":
-            self.accel_group.disconnect(self._open_terminal)
-            self._create_accel_group()
+  def _bind_shortcut(self, gsettings, key):
+    if key == GSETTINGS_OPEN_TERMINAL:
+      self._accel_group.disconnect(self._open_terminal)
+      self._create_accel_group()
 
-    def _open_terminal(self, *args):
-        filename = unquote(self.uri[7:])
-        open_terminl_in_file(filename)
+  def _open_terminal(self, *args):
+    filename = unquote(self._uri[7:])
+    open_terminl_in_file(filename)
 
-    def get_widget(self, uri, window):
-        self.uri = uri
-        if self.window:
-            self.window.remove_accel_group(self.accel_group)
-        window.add_accel_group(self.accel_group)
-        self.window = window
-        return None
+  def get_widget(self, uri, window):
+    self._uri = uri
+    if self._window:
+      self._window.remove_accel_group(self._accel_group)
+    if self._gsettings:
+      window.add_accel_group(self._accel_group)
+    self._window = window
+    return None
 
 
 class OpenTilixExtension(GObject.GObject, Nautilus.MenuProvider):
 
-    def _open_terminal(self, file):
-        if file.get_uri_scheme() in ['ftp', 'sftp']:
-            result = urlparse(file.get_uri())
-            if result.username:
-                value = 'ssh -t {0}@{1}'.format(result.username,
-                                                result.hostname)
-            else:
-                value = 'ssh -t {0}'.format(result.hostname)
-            if result.port:
-                value = "{0} -p {1}".format(value, result.port)
-            if file.is_directory():
-                value = '{0} cd "{1}" ; $SHELL'.format(value, result.path)
+  def _open_terminal(self, file_):
+    if file_.get_uri_scheme() in REMOTE_URI_SCHEME:
+      result = urlparse(file_.get_uri())
+      if result.username:
+        value = 'ssh -t {0}@{1}'.format(result.username,
+                                        result.hostname)
+      else:
+        value = 'ssh -t {0}'.format(result.hostname)
+      if result.port:
+        value = "{0} -p {1}".format(value, result.port)
+      if file_.is_directory():
+        value = '{0} cd "{1}" ; $SHELL'.format(value, result.path)
 
-            call('{0} -e "{1}" &'.format(TERMINAL, value), shell=True)
-        else:
-            gfile = Gio.File.new_for_uri(file.get_uri())
-            filename = gfile.get_path()
-            open_terminl_in_file(filename)
+      call('{0} -e "{1}" &'.format(TERMINAL, value), shell=True)
+    else:
+      filename = Gio.File.new_for_uri(file_.get_uri()).get_path()
+      open_terminl_in_file(filename)
 
-    def menu_activate_cb(self, menu, file):
-        self._open_terminal(file)
+  def _menu_activate_cb(self, menu, file_):
+    self._open_terminal(file_)
 
-    def menu_background_activate_cb(self, menu, file):
-        self._open_terminal(file)
+  def _menu_background_activate_cb(self, menu, file_):
+    self._open_terminal(file_)
 
-    def get_file_items(self, window, files):
-        if len(files) != 1:
-            print("Number of files is %d" % len(files))
-            return
-        items = []
-        file = files[0]
-        print("Handling file: ", file.get_uri())
-        print("file scheme: ", file.get_uri_scheme())
+  def get_file_items(self, window, files):
+    if len(files) != 1:
+      return
+    items = []
+    file_ = files[0]
+    print("Handling file: ", file_.get_uri())
+    print("file scheme: ", file_.get_uri_scheme())
 
-        if file.is_directory():  # and file.get_uri_scheme() == 'file':
+    if file_.is_directory():
 
-            if file.get_uri_scheme() in ['ftp', 'sftp']:
-                item = Nautilus.MenuItem(name='NautilusPython::openterminal_remote_item',
-                                         label=_(u'Open Remote Tilix'),
-                                         tip=_(u'Open Remote Tilix In %s') % file.get_uri())
-                item.connect('activate', self.menu_activate_cb, file)
-                items.append(item)
-
-            filename = file.get_name()
-
-            item = Nautilus.MenuItem(name='NautilusPython::openterminal_file_item',
-                                     label=_(u'Open In Tilix'),
-                                     tip=_(u'Open Tilix In %s') % filename)
-            item.connect('activate', self.menu_activate_cb, file)
-            items.append(item)
-
-        return items
-
-    def get_background_items(self, window, file):
-        items = []
-        if file.get_uri_scheme() in ['ftp', 'sftp']:
-            item = Nautilus.MenuItem(name='NautilusPython::openterminal_bg_remote_item',
-                                     label=_(u'Open Remote Tilix Here'),
-                                     tip=_(u'Open Remote Tilix In This Directory'))
-            item.connect('activate', self.menu_activate_cb, file)
-            items.append(item)
-
-        item = Nautilus.MenuItem(name='NautilusPython::openterminal_bg_file_item',
-                                 label=_(u'Open Tilix Here'),
-                                 tip=_(u'Open Tilix In This Directory'))
-        item.connect('activate', self.menu_background_activate_cb, file)
+      if file_.get_uri_scheme() in REMOTE_URI_SCHEME:
+        item = Nautilus.MenuItem(name='NautilusPython::open_remote_item',
+                                 label=_(u'Open Remote Tilix'),
+                                 tip=_(u'Open Remote Tilix '
+                                       'In').format(file_.get_uri()))
+        item.connect('activate', self._menu_activate_cb, file_)
         items.append(item)
-        return items
+
+      filename = file_.get_name()
+
+      item = Nautilus.MenuItem(name='NautilusPython::open_file_item',
+                               label=_(u'Open In Tilix'),
+                               tip=_(u'Open Tilix In {}').format(filename))
+      item.connect('activate', self._menu_activate_cb, file_)
+      items.append(item)
+
+    return items
+
+  def get_background_items(self, window, file_):
+    items = []
+    if file_.get_uri_scheme() in REMOTE_URI_SCHEME:
+      item = Nautilus.MenuItem(name='NautilusPython::open_bg_remote_item',
+                               label=_(u'Open Remote Tilix Here'),
+                               tip=_(u'Open Remote Tilix In This Directory'))
+      item.connect('activate', self._menu_activate_cb, file_)
+      items.append(item)
+
+    item = Nautilus.MenuItem(name='NautilusPython::open_bg_file_item',
+                             label=_(u'Open Tilix Here'),
+                             tip=_(u'Open Tilix In This Directory'))
+    item.connect('activate', self._menu_background_activate_cb, file_)
+    items.append(item)
+    return items


### PR DESCRIPTION
Just making the extension code more pythonic 
- Sort imports and remove unneeded ones
- Make use of some constants (easier to modify later)
- `file` shouldn't be used as a variable name
-  respect PEP8 a little bit more (not perfect due to `require_version`)
- Removed a print that was sending an unneeded output for each action you do on Nautilus (doesn't affect the user at all, but as I usually modify/create Nautilus stuff it just shows a lot of outputs for no reason....) 