### PR TITLE
Define the HOSTNAME Variable in tilix_int.sh

### DIFF
--- a/data/scripts/tilix_int.sh
+++ b/data/scripts/tilix_int.sh
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+HOSTNAME=$(hostname)
 
 # Not bash or zsh?
 [ -n "$BASH_VERSION" -o -n "$ZSH_VERSION" ] || return 0

--- a/data/scripts/tilix_int.sh
+++ b/data/scripts/tilix_int.sh
@@ -16,9 +16,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-HOSTNAME=$(hostname)
-
+if [ -z ${HOSTNAME+x} ]
+then
+  HOSTNAME=$(hostname)
+fi
 # Not bash or zsh?
 [ -n "$BASH_VERSION" -o -n "$ZSH_VERSION" ] || return 0
 


### PR DESCRIPTION
On Debian the HOSTNAME variable wasn't define, using a call the the hostname bin populate it.