### PR TITLE
Fix issue with running Tilix after manual compiling to custom directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ dub build --build=release
 ```
 
 The application depends on various resources to function correctly, run `sudo ./install.sh` to build and copy all of the resources to the correct locations. Note this has only been tested on Arch Linux, use with caution.
+Note : `install.sh` will install Tilix to your `/usr` directory. If you are interested in installing Tilix to a custom location, you can specify the `PREFIX` as an argument to `install.sh` script (e.g : `./install.sh $HOME/.local` will install Tilix into `$HOME/.local`). While installing to custom directories seem to be working fine ([with one exception](https://github.com/gnunn1/tilix/wiki/Installing-to-custom-directory)) and doesn't require `sudo` privileges; please be warned that you will have to re-compile the glib schema manually and this would require `sudo` privileges.
 
 Note there is also experimental support for autotools, please see the wiki page on [autotools](https://github.com/gnunn1/tilix/wiki/Building-with-Autotools) for more information.
 

--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,7 @@ else
     echo "Please refer to https://github.com/gnunn1/tilix/wiki/Installing-to-custom-directory on how to do this manually"
     echo "Continuing with the rest of the install"
     echo
+    set GLIB_SCHEMA_NOT_INSTALLED=true
 fi
 
 export TERMINIX_SHARE=${PREFIX}/share/tilix
@@ -154,4 +155,17 @@ if [ "$PREFIX" = '/usr' ] || [ "$PREFIX" = "/usr/local" ]; then
 
     echo "Updating icon cache"
     gtk-update-icon-cache -f ${PREFIX}/share/icons/hicolor/
+fi
+
+if [ GLIB_SCHEMA_NOT_INSTALLED ]; then
+    echo
+    echo "\033[0;31m WARNING : "
+    echo "Tilix was installed to ${PREFIX} without compiling schemas for glib-2.0"
+    echo "Tilix requires to compile some schemas for glib-2.0 which require sudo privileges and without which Tilix will not work \033[0m"
+    echo "Please refer to https://github.com/gnunn1/tilix/wiki/Installing-to-custom-directory on how to do this manually"
+    echo
+    unset GLIB_SCHEMA_NOT_INSTALLED
+    exit 1
+else
+    echo "Tilix was installed successfully to ${PREFIX}/bin"
 fi

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ else
     export PREFIX=$1
 fi
 
-if [ "$PREFIX" = "/usr" ] && [ "$(id -u)" != "0" ]; then
+if [ "$PREFIX" = "/usr" ] && [ $(id -u) -ne 0 ]; then
     # Make sure only root can run our script
     echo "This script must be run as root" 1>&2
     exit 1
@@ -38,7 +38,7 @@ done
 
 echo "Installing to prefix ${PREFIX}"
 
-if [ "${PREFIX}" = "/usr" ] || [ "$(id -u)" == "0" ]; then
+if [ "${PREFIX}" = "/usr" ] || [ $(id -u) -eq 0 ]; then
     # Copy and compile schema
     echo "Copying and compiling schema..."
     install -d /usr/share/glib-2.0/schemas

--- a/install.sh
+++ b/install.sh
@@ -38,11 +38,20 @@ done
 
 echo "Installing to prefix ${PREFIX}"
 
-# Copy and compile schema
-echo "Copying and compiling schema..."
-install -d ${PREFIX}/share/glib-2.0/schemas
-install -m 644 data/gsettings/com.gexperts.Tilix.gschema.xml ${PREFIX}/share/glib-2.0/schemas/
-glib-compile-schemas ${PREFIX}/share/glib-2.0/schemas/
+if [ "${PREFIX}" = "/usr" ] || [ "$(id -u)" == "0" ]; then
+    # Copy and compile schema
+    echo "Copying and compiling schema..."
+    install -d /usr/share/glib-2.0/schemas
+    install -m 644 data/gsettings/com.gexperts.Tilix.gschema.xml /usr/share/glib-2.0/schemas/
+    glib-compile-schemas /usr/share/glib-2.0/schemas/
+else
+    echo
+    echo "Tilix is being installed to ${PREFIX} without sudo privileges"
+    echo "Tilix requires to compile some schemas for glib-2.0 which require sudo privileges and without which Tilix will not work"
+    echo "Please refer to https://github.com/gnunn1/tilix/wiki/Installing-to-custom-directory on how to do this manually"
+    echo "Continuing with the rest of the install"
+    echo
+fi
 
 export TERMINIX_SHARE=${PREFIX}/share/tilix
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -14,8 +14,17 @@ fi
 echo "Uninstalling from prefix ${PREFIX}"
 
 rm ${PREFIX}/bin/tilix
-rm ${PREFIX}/share/glib-2.0/schemas/com.gexperts.Tilix.gschema.xml
-glib-compile-schemas ${PREFIX}/share/glib-2.0/schemas/
+if [ "${PREFIX}" = "/usr" ] || [ "$(id -u)" == "0" ]; then
+    rm /usr/share/glib-2.0/schemas/com.gexperts.Tilix.gschema.xml
+    glib-compile-schemas /usr/share/glib-2.0/schemas/
+else
+    echo
+    echo "sudo privileges is required to remove the glib-2.0 schema (/usr/share/glib-2.0/schemas/com.gexperts.Tilix.gschema.xml) that was installed for Tilix"
+    echo "Please remove the gschema manually and then re-compile the gschema by runnig"
+    echo "sudo glib-compile-schemas /usr/share/glib-2.0/schemas/"
+    echo "Comtinuing with the rest of the uninstall"
+    echo
+fi
 rm -rf ${PREFIX}/share/tilix
 
 find ${PREFIX}/share/locale -type f -name "tilix.mo" -delete

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -24,6 +24,7 @@ else
     echo "sudo glib-compile-schemas /usr/share/glib-2.0/schemas/"
     echo "Comtinuing with the rest of the uninstall"
     echo
+    set GLIB_SCHEMA_UNINSTALL_SKIPPED=true
 fi
 rm -rf ${PREFIX}/share/tilix
 
@@ -36,3 +37,12 @@ rm ${PREFIX}/share/applications/com.gexperts.Tilix.desktop
 rm ${PREFIX}/share/metainfo/com.gexperts.Tilix.appdata.xml
 rm ${PREFIX}/share/man/man1/tilix.1.gz
 rm ${PREFIX}/share/man/*/man1/tilix.1.gz
+
+if [ GLIB_SCHEMA_UNINSTALL_SKIPPED ]; then
+    echo
+    echo "\033[0;31m The gschema that was installed for Tilix (/usr/share/glib-2.0/schemas/com.gexperts.Tilix.gschema.xml) could not be removed \033[0m"
+    echo "Please remove the gschema manually and then re-compile the gschema by runnig"
+    echo "sudo glib-compile-schemas /usr/share/glib-2.0/schemas/"
+    echo
+    exit 1
+fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,7 +3,7 @@
 if [ -z  "$1" ]; then
     export PREFIX=/usr
     # Make sure only root can run our script
-    if [ "$(id -u)" != "0" ]; then
+    if [ $(id -u) -ne 0 ]; then
         echo "This script must be run as root" 1>&2
         exit 1
     fi
@@ -14,7 +14,7 @@ fi
 echo "Uninstalling from prefix ${PREFIX}"
 
 rm ${PREFIX}/bin/tilix
-if [ "${PREFIX}" = "/usr" ] || [ "$(id -u)" == "0" ]; then
+if [ "${PREFIX}" = "/usr" ] || [ $(id -u) -eq 0 ]; then
     rm /usr/share/glib-2.0/schemas/com.gexperts.Tilix.gschema.xml
     glib-compile-schemas /usr/share/glib-2.0/schemas/
 else


### PR DESCRIPTION
This fixes Issue #1018.

Changes : 
* Locked the installation of gschema to the `/usr` directory as there are no way around it to install gschema to a custom location.
* Added checks for `PREFIX` and `sudo` privileges before installing gschema
* Added some warnings for users that try to install to custom directories without `sudo` privileges.
* Modified user id checks for `root` from string to numeric.
* Updated README with relevant information about installing to custom directories.