### PR TITLE
[RFC] add total number of sessions in application title

### DIFF
--- a/source/gx/tilix/appwindow.d
+++ b/source/gx/tilix/appwindow.d
@@ -1066,9 +1066,11 @@ private:
         if (session) {
             title = session.getDisplayText(title);
             title = title.replace(VARIABLE_SESSION_NUMBER, to!string(nb.getCurrentPage()+1));
+            title = title.replace(VARIABLE_SESSION_COUNT, to!string(nb.getNPages()));
             title = title.replace(VARIABLE_SESSION_NAME, session.displayName);
         } else {
             title = title.replace(VARIABLE_SESSION_NUMBER, to!string(nb.getCurrentPage()+1));
+            title = title.replace(VARIABLE_SESSION_COUNT, to!string(nb.getNPages()));
             title = title.replace(VARIABLE_SESSION_NAME, _("Default"));
         }
         return title;

--- a/source/gx/tilix/constants.d
+++ b/source/gx/tilix/constants.d
@@ -173,12 +173,14 @@ enum VARIABLE_APP_NAME = "${appName}";
 enum VARIABLE_ACTIVE_TERMINAL_TITLE = "${activeTerminalTitle}";
 enum VARIABLE_SESSION_NAME = "${sessionName}";
 enum VARIABLE_SESSION_NUMBER = "${sessionNumber}";
+enum VARIABLE_SESSION_COUNT = "${sessionCount}";
 
 immutable string[] VARIABLE_WINDOW_VALUES = [
     VARIABLE_APP_NAME,
     VARIABLE_ACTIVE_TERMINAL_TITLE,
     VARIABLE_SESSION_NAME,
     VARIABLE_SESSION_NUMBER,
+    VARIABLE_SESSION_COUNT,
 ];
 
 immutable string[] VARIABLE_WINDOW_LOCALIZED = [
@@ -186,4 +188,5 @@ immutable string[] VARIABLE_WINDOW_LOCALIZED = [
     N_("Active terminal title"),
     N_("Session name"),
     N_("Session number"),
+    N_("Session count"),
 ];


### PR DESCRIPTION
I use this patch to show the total session number in the application title. A usecase is having the current session / total session, for example 1/2 :

![screen](https://user-images.githubusercontent.com/9877335/29254958-88d33cac-8051-11e7-9422-0df4bc0ebc69.png)
