### PR TITLE
Fix Flatpak build

### DIFF
--- a/source/gx/tilix/appwindow.d
+++ b/source/gx/tilix/appwindow.d
@@ -1765,17 +1765,6 @@ public:
         }
         //Create an initial session using default session name and profile
         createSession(gsSettings.getString(SETTINGS_SESSION_NAME_KEY), prfMgr.getDefaultProfile());
-
-        static if (FLATPAK) {
-            // Inside flatpak sandbox first session complains:
-            //      sh: cannot set terminal process group (-1): Inappropriate ioctl for device
-            //      sh: no job control in this shell
-            Session init_session = getSession(0);
-            if (init_session !is null) {
-                createSession(gsSettings.getString(SETTINGS_SESSION_NAME_KEY), prfMgr.getDefaultProfile());
-                closeSession(init_session);
-            }
-        }
     }
 
     void initialize(Session session) {

--- a/source/gx/tilix/terminal/exvte.d
+++ b/source/gx/tilix/terminal/exvte.d
@@ -263,6 +263,7 @@ public:
      * as well which also indicates no child process.
      */
     pid_t getChildPid() {
+        // TODO: be correct for flatpak sandbox
         if (getPty() is null)
             return false;
         return tcgetpgrp(getPty().getFd());

--- a/source/gx/tilix/terminal/exvte.d
+++ b/source/gx/tilix/terminal/exvte.d
@@ -18,6 +18,8 @@ import glib.Str;
 import vte.Terminal;
 import vtec.vtetypes;
 
+import gx.tilix.constants;
+
 enum TerminalScreen {
     NORMAL = 0,
     ALTERNATE = 1
@@ -264,9 +266,13 @@ public:
      */
     pid_t getChildPid() {
         // TODO: be correct for flatpak sandbox
-        if (getPty() is null)
-            return false;
-        return tcgetpgrp(getPty().getFd());
+		static if (FLATPAK) {
+			return -1;
+		} else {
+			if (getPty() is null)
+            	return false;
+        	return tcgetpgrp(getPty().getFd());
+		}
     }
 
 }

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2545,18 +2545,21 @@ private:
 
             int pty_master = pty.getFd();
 
-            if (core.sys.posix.stdlib.grantpt(pty_master) != 0) {
+            import core.sys.posix.stdlib: grantpt, unlockpt, ptsname;
+            import core.sys.posix.fcntl: open, O_RDWR;
+
+            if (grantpt(pty_master) != 0) {
                 warning("Failed granting access to slave pseudoterminal device");
                 return false;
             }
 
-            if (core.sys.posix.stdlib.unlockpt(pty_master) != 0) {
+            if (unlockpt(pty_master) != 0) {
                 warning("Failed unlocking slave pseudoterminal device");
                 return false;
             }
 
             int[] pty_slaves;
-            pty_slaves ~= core.sys.posix.fcntl.open(core.sys.posix.stdlib.ptsname(pty_master), core.sys.posix.fcntl.O_RDWR);
+            pty_slaves ~= open(ptsname(pty_master), O_RDWR);
             if (pty_slaves[0] < 0) {
                 warning("Failed opening slave pseudoterminal device");
                 return false;

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2570,6 +2570,7 @@ private:
             }
 
             envv ~= ["TERM=" ~"xterm-256color"];
+            envv ~= ["LANG=" ~ environment.get("LANG")];
 
             bool result = sendHostCommand(pty, workingDir, args, envv, pty_slaves);
 

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2556,14 +2556,14 @@ private:
             }
 
             int[] pty_slaves;
-            int pty_slave = core.sys.posix.fcntl.open(core.sys.posix.stdlib.ptsname(pty_master), core.sys.posix.fcntl.O_RDWR);
-            if (pty_slave < 0) {
+            pty_slaves ~= core.sys.posix.fcntl.open(core.sys.posix.stdlib.ptsname(pty_master), core.sys.posix.fcntl.O_RDWR);
+            if (pty_slaves[0] < 0) {
                 warning("Failed opening slave pseudoterminal device");
                 return false;
             }
 
-            foreach(i; 0 .. 3) {
-                pty_slaves ~= core.sys.posix.unistd.dup(pty_slave);
+            foreach(i; 0 .. 2) {
+                pty_slaves ~= core.sys.posix.unistd.dup(pty_slaves[0]);
             }
 
             envv ~= ["TERM=" ~"xterm-256color"];

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2633,10 +2633,9 @@ private:
             }
         }
 
-        DBusConnection connection = DBusConnection.newForAddressSync(
-            g_getenv ("DBUS_SESSION_BUS_ADDRESS"),
-            G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT | G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION,
-            null,
+        DBusConnection connection = new DBusConnection (
+            environment.get("DBUS_SESSION_BUS_ADDRESS"),
+            GDBusConnectionFlags.AUTHENTICATION_CLIENT | GDBusConnectionFlags.MESSAGE_BUS_CONNECTION,
             null,
             null
         );

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2572,7 +2572,7 @@ private:
             envv ~= ["TERM=" ~"xterm-256color"];
             envv ~= ["LANG=" ~ environment.get("LANG")];
 
-            bool result = sendHostCommand(pty, workingDir, args, envv, pty_slaves);
+            bool result = sendHostCommand(pty, workingDir, args, envv, pty_slaves, gpid);
 
             vte.setPty(pty);
 
@@ -2619,7 +2619,7 @@ private:
 
     enum O_CLOEXEC = 0x80000;
 
-    bool sendHostCommand(Pty pty, string workingDir, string[] args, string[] envv, int[] stdio_fds) {
+    bool sendHostCommand(Pty pty, string workingDir, string[] args, string[] envv, int[] stdio_fds, out int gpid) {
         import gio.DBusConnection;
         import gio.UnixFDList;
 
@@ -2662,6 +2662,9 @@ private:
             warning("No reply from flatpak dbus service");
             return false;
         } else {
+            uint pid;
+            g_variant_get (reply.getVariantStruct(), "(u)", &pid);
+            gpid = pid;
             return true;
         }
     }
@@ -3443,6 +3446,7 @@ public:
      * returns the name
      */
     bool isProcessRunning(out string name) {
+        // TODO: be correct for flatpak sandbox
         if (vte.getPty() is null)
             return false;
         pid_t childPid;

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2569,8 +2569,10 @@ private:
                 pty_slaves ~= core.sys.posix.unistd.dup(pty_slaves[0]);
             }
 
+            import VteVersion = vte.Version;
+
             envv ~= ["TERM=" ~"xterm-256color"];
-            envv ~= ["VTE_VERSION=" ~]
+            envv ~= [format("VTE_VERSION=%02u%02u", VteVersion.Version.getMinorVersion(), VteVersion.Version.getMicroVersion())];
 
             string[] igneredEnvv = [
                 "PATH",

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2547,20 +2547,23 @@ private:
 
             if (core.sys.posix.stdlib.grantpt(pty_master) != 0) {
                 warning("Failed granting access to slave pseudoterminal device");
+                return false;
             }
 
             if (core.sys.posix.stdlib.unlockpt(pty_master) != 0) {
                 warning("Failed unlocking slave pseudoterminal device");
+                return false;
             }
 
             int[] pty_slaves;
             int pty_slave = core.sys.posix.fcntl.open(core.sys.posix.stdlib.ptsname(pty_master), core.sys.posix.fcntl.O_RDWR);
             if (pty_slave < 0) {
                 warning("Failed opening slave pseudoterminal device");
-            } else {
-                foreach(i; 0 .. 3) {
-                    pty_slaves ~= core.sys.posix.unistd.dup(pty_slave);
-                }
+                return false;
+            }
+
+            foreach(i; 0 .. 3) {
+                pty_slaves ~= core.sys.posix.unistd.dup(pty_slave);
             }
 
             envv ~= ["TERM=" ~"xterm-256color"];

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2583,15 +2583,10 @@ private:
         GVariantBuilder envBuilder = new GVariantBuilder(new GVariantType("a{ss}"));
         foreach(env; envv) {
             string[] envPair = env.split("=");
-            // TODO: filter more flatpak env vars
-            if (envPair[0] != "PATH") {
-                tracef("Adding env var %s=%s", envPair[0], envPair[1]);
-                if (envPair.length ==2) {
-                    GVariant pair = new GVariant(new GVariant(envPair[0]), new GVariant(envPair[1]));
-                    envBuilder.addValue(pair);
-                }
-            } else {
-                tracef("Ignoring env var %s=%s", envPair[0], envPair[1]);
+            tracef("Adding env var %s=%s", envPair[0], envPair[1]);
+            if (envPair.length ==2) {
+                GVariant pair = new GVariant(new GVariant(envPair[0]), new GVariant(envPair[1]));
+                envBuilder.addValue(pair);
             }
         }
 

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2529,6 +2529,8 @@ private:
         vte.grabFocus();
     }
 
+    enum O_CLOEXEC = 0x80000;
+
     /**
      * Needed spawnSync function to handle flatpak where we need to generate out VtePty in order
      * for it to work at the system level outside of flatpak.
@@ -2559,7 +2561,7 @@ private:
             }
 
             int[] pty_slaves;
-            pty_slaves ~= open(ptsname(pty_master), O_RDWR);
+            pty_slaves ~= open(ptsname(pty_master), O_RDWR | O_CLOEXEC);
             if (pty_slaves[0] < 0) {
                 warning("Failed opening slave pseudoterminal device");
                 return false;
@@ -2639,8 +2641,6 @@ private:
 
         return new GVariant(vs, true);
     }
-
-    enum O_CLOEXEC = 0x80000;
 
     bool sendHostCommand(Pty pty, string workingDir, string[] args, string[] envv, int[] stdio_fds, out int gpid) {
         import gio.DBusConnection;

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2633,7 +2633,14 @@ private:
             }
         }
 
-        DBusConnection connection = tilix.getDbusConnection();
+        DBusConnection connection = DBusConnection.newForAddressSync(
+            g_getenv ("DBUS_SESSION_BUS_ADDRESS"),
+            G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT | G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION,
+            null,
+            null,
+            null
+        );
+        connection.setExitOnClose(false);
 
         // TODO: handle HostCommandExited signal
 

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2570,7 +2570,28 @@ private:
             }
 
             envv ~= ["TERM=" ~"xterm-256color"];
-            envv ~= ["LANG=" ~ environment.get("LANG")];
+            envv ~= ["VTE_VERSION=" ~]
+
+            string[] igneredEnvv = [
+                "PATH",
+                "LD_LIBRARY_PATH",
+                "XDG_CONFIG_DIRS",
+                "XDG_CONFIG_HOME",
+                "XDG_DATA_DIRS",
+                "XDG_DATA_HOME",
+                "XDG_CACHE_HOME",
+                "XDG_RUNTIME_DIR",
+                "GST_PLUGIN_SYSTEM_PATH",
+                "DCONF_USER_CONFIG_DIR",
+                "GI_TYPELIB_PATH",
+                "DISPLAY",
+            ];
+            string[string] envParent = environment.toAA();
+            foreach(key; envParent.byKey()) {
+                if (!igneredEnvv.canFind(key)) {
+                    envv ~= [key ~ "=" ~ envParent[key]];
+                }
+            }
 
             bool result = sendHostCommand(pty, workingDir, args, envv, pty_slaves, gpid);
 

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2547,10 +2547,6 @@ private:
             vte_pty_child_setup(pty.getPtyStruct());
 
             envv ~= ["TERM=" ~"xterm-256color"];
-            string[string] envParent = environment.toAA();
-            foreach(key; envParent.byKey()) {
-                envv ~= [key ~ "=" ~ envParent[key]];
-            }
 
             bool result = sendHostCommand(pty, workingDir, args, envv);
 


### PR DESCRIPTION
- ~~Do not crash when opening window (it still sometimes crash when closing window)~~
- Keep stdio usable
- Use env vars from host, so that more commands work (for example `flatpak remote-list`)
Issue #582 