### PR TITLE
Flatpak improvements

### DIFF
--- a/experimental/flatpak/com.gexperts.Tilix.json
+++ b/experimental/flatpak/com.gexperts.Tilix.json
@@ -19,7 +19,9 @@
                         "--talk-name=org.freedesktop.Flatpak",
                         "--own-name=com.gexperts.Tilix",
                         "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
-                        "--allow=devel"],
+                        "--allow=devel",
+                        /* share pseudoterminal device with host */
+                        "--device=all"],
         "modules": [
                 {
                         "name": "dmd",

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -2589,6 +2589,8 @@ private:
                 "DCONF_USER_CONFIG_DIR",
                 "GI_TYPELIB_PATH",
                 "DISPLAY",
+                "TERM",
+                "VTE_VERSION"
             ];
             string[string] envParent = environment.toAA();
             foreach(key; envParent.byKey()) {


### PR DESCRIPTION
- Share pseudoterminal devices with host (and every other device)
- Do not overwrite TERM and VTE_VERSION env vars.