### PR TITLE
Clarify compiler support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Tilix is localized using Weblate, please visit the Weblate hosted [Tilix transla
 
 ### Building
 
-Tilix is written in D and GTK 3 using the gtkd framework. This project uses dub to manage the build process including fetching the dependencies, thus there is no need to install dependencies manually. The only thing you need to install to build the application is the D tools (DMD and Phobos) along with dub itself. Note that D supports three compilers (DMD, GDC and LDC) and Tilix only supports DMD.
+Tilix is written in [D](https://dlang.org/) and GTK 3 using the gtkd framework. This project uses dub to manage the build process including fetching the dependencies, thus there is no need to install dependencies manually. The only thing you need to install to build the application is the D tools (compiler and Phobos) along with dub itself. Note that D supports three [compilers](https://wiki.dlang.org/Compilers) (DMD, GDC and LDC) but Tilix only supports DMD and LDC.
 
 Once you have those installed, compiling the application is a one line command as follows:
 


### PR DESCRIPTION
In https://github.com/gnunn1/tilix/issues/1168#issuecomment-340264899 gnunn1 said:

> LDC is supported, it says not supported somewhere then that should be corrected. It's GDC that's not supported.

This PR clarifies the compiler support in the README to match this.