### PR TITLE
Fix the build on 32 bit arches

### DIFF
--- a/source/gx/tilix/terminal/activeprocess.d
+++ b/source/gx/tilix/terminal/activeprocess.d
@@ -39,7 +39,7 @@ class Process {
     string[] parseStatFile() {
         try {
             string data = to!string(cast(char[])read(format("/proc/%d/stat", pid)));
-            long rpar = data.lastIndexOf(")");
+            size_t rpar = data.lastIndexOf(")");
             string name = data[data.indexOf("(") + 1..rpar];
             string[] other  = data[rpar + 2..data.length].split;
             return name ~ other;


### PR DESCRIPTION
source/gx/tilix/terminal/activeprocess.d(43): Error: cannot implicitly convert expression (rpar) of type long to uint
source/gx/tilix/terminal/activeprocess.d(44): Error: cannot implicitly convert expression (rpar + 2L) of type long to uint