### PR TITLE
Add DCFLAGS to linking, fixes #1243

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ tilix.o: $(tilix_SOURCES)
 	$(DC) $(DCFLAGS) $(GTKD_CFLAGS) $(GTKD_LIBS) -c $^ -of$@
 # libx11 is a C library, so we need to precede with -L
 tilix$(EXEEXT): tilix.o
-	$(DC) $(GTKD_LIBS) $(addprefix -L,$(X11_LIBS)) $^ -of$@
+	$(DC) $(DCFLAGS) $(GTKD_LIBS) $(addprefix -L,$(X11_LIBS)) $^ -of$@
 
 gschemasdir = $(datadir)/glib-2.0/schemas/
 dist_gschemas_DATA = $(srcdir)/data/gsettings/com.gexperts.Tilix.gschema.xml


### PR DESCRIPTION
This fixes so Tilix can run on Archlinux again.
Without this Tilix will always link to the staticlibs of druntime/phobos, due to it ignoring the DCFLAGS.

The Arch package also requires this patch:
```patch
From 4f0f7eb8211a83d57d89a5aeb0211c47f9ae1baf Mon Sep 17 00:00:00 2001
From: Dan Printzell <xwildn00bx@gmail.com>
Date: Mon, 8 Jan 2018 15:03:02 +0100
Subject: [PATCH] Link to the shared version of druntime&phobos

Signed-off-by: Dan Printzell <xwildn00bx@gmail.com>
---
 PKGBUILD | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

diff --git a/PKGBUILD b/PKGBUILD
index b4ee388..8d0b421 100644
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -30,8 +30,8 @@ prepare() {
 
 build() {
     cd "$pkgname-$pkgver"
-    ./configure --prefix=/usr PO4A_TRANS=/usr/bin/vendor_perl/po4a-translate
-    make DC='ldmd' DCFLAGS='-O -inline -release -version=StdLoggerDisableTrace'
+    ./configure --prefix=/usr PO4A_TRANS=/usr/bin/vendor_perl/po4a-translate DC='ldmd' DCFLAGS='-O -inli
+    make
 }
 
 package() {
-- 
2.15.1

```

Fixes #1243