### PR TITLE
Fix transform func misstyping '/' -> '\'

### DIFF
--- a/source/gx/tilix/terminal/advpaste.d
+++ b/source/gx/tilix/terminal/advpaste.d
@@ -125,8 +125,8 @@ private:
             text = text.detab(gsSettings.getInt(SETTINGS_ADVANCED_PASTE_SPACE_COUNT_KEY));
         }
         if (gsSettings.getBoolean(SETTINGS_ADVANCED_PASTE_REPLACE_CRLF_KEY)) {
-            text = text.replace("/r/n", "/n");
-            text = text.replace("/r", "/n");
+            text = text.replace("\r\n", "\n");
+            text = text.replace("\r", "\n");
 
         }
         return text;


### PR DESCRIPTION
This fixs paste trasnform function.
Its motto is replaceing CRLF & CR to LF but it replace '/r/n' & '/r' -> '/n'.
So Fix ' / ' -> ' \ '.