### PR TITLE
Add auto-oriented splitting (Request for feedback from community)

### DIFF
--- a/data/gsettings/com.gexperts.Tilix.gschema.xml
+++ b/data/gsettings/com.gexperts.Tilix.gschema.xml
@@ -1013,6 +1013,10 @@
       <default>'&lt;Ctrl&gt;&lt;Alt&gt;d'</default>
       <summary>Keyboard shortcut to add new terminal down</summary>
     </key>
+    <key name="session-add-auto" type="s">
+      <default>'&lt;Ctrl&gt;&lt;Alt&gt;a'</default>
+      <summary>Keyboard shortcut to add new terminal automatically</summary>
+    </key>
     <key name="win-view-sidebar" type="s">
       <default>'F12'</default>
       <summary>Keyboard shortcut to view session sidebar</summary>

--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -194,6 +194,10 @@
                 <property name="visible">1</property>
                 <property name="title" translatable="yes" context="shortcut window">Add terminal down</property>
               </object>
+              <object class="GtkShortcutsShortcut" id ="session-add-auto">
+                <property name="visible">1</property>
+                <property name="title" translatable="yes" context="shortcut window">Add terminal automatically</property>
+              </object>
             </child>
           </object>
         </child>

--- a/source/gx/tilix/appwindow.d
+++ b/source/gx/tilix/appwindow.d
@@ -118,6 +118,7 @@ public:
     enum ACTION_PREFIX = "session";
     enum ACTION_SESSION_ADD_RIGHT = "add-right";
     enum ACTION_SESSION_ADD_DOWN = "add-down";
+    enum ACTION_SESSION_ADD_AUTO = "add-auto";
 
 private:
 
@@ -161,6 +162,7 @@ private:
     SimpleAction saViewSideBar;
     SimpleAction saSessionAddRight;
     SimpleAction saSessionAddDown;
+    SimpleAction saSessionAddAuto;
 
     Label lblSideBar;
 
@@ -596,8 +598,13 @@ private:
         });
         saSessionAddDown = registerActionWithSettings(sessionActions, ACTION_PREFIX, ACTION_SESSION_ADD_DOWN, gsShortcuts, delegate(GVariant, SimpleAction) {
             Session session = getCurrentSession();
-            if (session !is null && !session.maximized) 
+            if (session !is null && !session.maximized)
                 session.addTerminal(Orientation.VERTICAL);
+        });
+        saSessionAddAuto = registerActionWithSettings(sessionActions, ACTION_PREFIX, ACTION_SESSION_ADD_AUTO, gsShortcuts, delegate(GVariant, SimpleAction) {
+            Session session = getCurrentSession();
+            if (session !is null && !session.maximized)
+                session.addAutoOrientedTerminal();
         });
 
         /* TODO - GTK doesn't support settings Tab for accelerators, need to look into this more */

--- a/source/gx/tilix/session.d
+++ b/source/gx/tilix/session.d
@@ -1462,6 +1462,27 @@ public:
         }
     }
 
+    /**
+      * Adds a new 'auto-oriented' terminal to the currently
+      * focused terminal by comparing the width and the height.
+      *
+      * When the height is greater than the width it
+      * splits the screen horizontally. When the width is greater
+      * than the height it splits the terminal vertically.
+      */
+    void addAutoOrientedTerminal() {
+        if (currentTerminal !is null) {
+            int height = currentTerminal.getAllocatedHeight();
+            int width = currentTerminal.getAllocatedWidth();
+
+            if (height < width) {
+                addNewTerminal(currentTerminal, Orientation.HORIZONTAL);
+            } else {
+                addNewTerminal(currentTerminal, Orientation.VERTICAL);
+            }
+        }
+    }
+
     @property bool maximized() {
         return maximizedInfo.isMaximized;
     }


### PR DESCRIPTION
Hello,

I came across this awesome project a couple of weeks ago and have been using this terminal emulator since then. So first of all thank you for developing and maintaining this great project!

Before using Tilix in GNOME I was using i3wm and I really liked the "auto-tiling" feature that allowed me to split screens vertically and horizontally with one key binding (mod + Enter). So I implemented it also for my new favorite terminal emulator.

This PR adds a new key to split a terminal depending on the current height and width.

Here's the result:
![tilix-pr](https://user-images.githubusercontent.com/12183932/37879531-b4de9aa6-307a-11e8-8029-3ed92343bfc3.png)
Here I pressed the "auto-tiling" key three times.

I would be glad to get some feedback on this PR and maybe see this feature implemented in the next
version of Tilix!