### PR TITLE
Missing letter.

### DIFF
--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -251,7 +251,7 @@ msgstr "Avansert innliming"
 #: source/gx/tilix/terminal/terminal.d:1809
 #: source/gx/tilix/terminal/terminal.d:1827
 msgid "Paste"
-msgstr "Lim in"
+msgstr "Lim inn"
 
 #: source/gx/tilix/terminal/search.d:125
 msgid "Search Options"


### PR DESCRIPTION
"Paste" == "Lim inn" in Norwegian.