### PR TITLE
Only show VTE config warning dialog when opening preferences 

### DIFF
--- a/source/gx/tilix/application.d
+++ b/source/gx/tilix/application.d
@@ -124,6 +124,7 @@ private:
     ImageSurface isFullBGImage;
 
     bool warnedVTEConfigIssue = false;
+    bool shouldWarnVTEConfigIssue = false;
 
     bool useTabs = false;
 
@@ -787,6 +788,9 @@ public:
         });
         preferenceDialog.showAll();
         preferenceDialog.present;
+
+        // show VTE config warning dialog if configuration issues were detected
+        showVTEConfigIssueWarning(preferenceDialog);
     }
 
     void presentProfilePreferences(ProfileInfo profile) {
@@ -859,17 +863,23 @@ public:
      * See Issue #34 and https://github.com/gnunn1/tilix/wiki/VTE-Configuration-Issue
      * for more information.
      */
-    void warnVTEConfigIssue() {
+    void showVTEConfigIssueWarning(Window parent = null) {
+        if (!shouldWarnVTEConfigIssue)
+            return;
+
+        if (parent is null)
+            parent = getActiveWindow();
+
         if (testVTEConfig()) {
             warnedVTEConfigIssue = true;
             string msg = _("There appears to be an issue with the configuration of the terminal.\nThis issue is not serious, but correcting it will improve your experience.\nClick the link below for more information:");
             string title = "<span weight='bold' size='larger'>" ~ _("Configuration Issue Detected") ~ "</span>";
-            MessageDialog dlg = new MessageDialog(getActiveWindow(), DialogFlags.MODAL, MessageType.WARNING, ButtonsType.OK, null, null);
+            MessageDialog dlg = new MessageDialog(parent, DialogFlags.MODAL, MessageType.WARNING, ButtonsType.OK, null, null);
             scope (exit) {
                 dlg.destroy();
             }
             with (dlg) {
-                setTransientFor(getActiveWindow());
+                setTransientFor(parent);
                 setMarkup(title);
                 getMessageArea().setMarginLeft(0);
                 getMessageArea().setMarginRight(0);
@@ -885,6 +895,15 @@ public:
                 }
             }
         }
+    }
+
+    /**
+     * To not throw a warning message at the user immediately when the
+     * terminal is initialized, we allow to schedule a warning and show
+     * it later (e.g. when the user opens the preferences dialog).
+     */
+    void setShouldWarnVTEConfigIssue(bool value) {
+        shouldWarnVTEConfigIssue = value;
     }
 
     /**

--- a/source/gx/tilix/application.d
+++ b/source/gx/tilix/application.d
@@ -698,7 +698,7 @@ public:
         if (newProcess) flags |= ApplicationFlags.NON_UNIQUE;
         //flags |= ApplicationFlags.CAN_OVERRIDE_APP_ID;
         super(APPLICATION_ID, flags);
-        
+
         if (group.length > 0) {
             string id = "com.gexperts.Tilix." ~ group;
             if (idIsValid(id)) {

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -1029,8 +1029,8 @@ private:
             event.getKeyval(keyval);
             if ((keyval == GdkKeysyms.GDK_c) && (event.key.state & ModifierType.CONTROL_MASK)) {
                 string[] actions = tilix.getActionsForAccel("<Ctrl>c");
-                if (actions.length > 0 && 
-                   (actions[0] == getActionDetailedName(ACTION_PREFIX,ACTION_COPY) || actions[0] == getActionDetailedName(ACTION_PREFIX,ACTION_COPY_AS_HTML)) && 
+                if (actions.length > 0 &&
+                   (actions[0] == getActionDetailedName(ACTION_PREFIX,ACTION_COPY) || actions[0] == getActionDetailedName(ACTION_PREFIX,ACTION_COPY_AS_HTML)) &&
                    !vte.getHasSelection()) {
                     string controlc = "\u0003";
                     vte.feedChild(controlc);
@@ -1995,7 +1995,7 @@ private:
             if (uri.startsWith("file:")) {
                 string filename, hostname;
                 try {
-                    
+
                     filename = URI.filenameFromUri(uri, hostname);
                 } catch (Exception e) {
                     string message = format(_("Could not check file '%s' due to error '%s'"), match.match, e.msg);
@@ -2415,7 +2415,7 @@ private:
             silenceThreshold = gsProfile.getInt(SETTINGS_PROFILE_NOTIFY_SILENCE_THRESHOLD_KEY);
             break;
         case SETTINGS_PROFILE_WORD_WISE_SELECT_CHARS_KEY:
-            if (vte !is null && checkVTEVersion(VTE_VERSION_WORD_WISE_SELECT_CHARS)) 
+            if (vte !is null && checkVTEVersion(VTE_VERSION_WORD_WISE_SELECT_CHARS))
                 vte.setWordCharExceptions(gsProfile.getString(SETTINGS_PROFILE_WORD_WISE_SELECT_CHARS_KEY));
             break;
         case SETTINGS_PROFILE_TEXT_BLINK_MODE_KEY:
@@ -4109,7 +4109,7 @@ public:
         } else {
             getMessageArea().add(lblCmd);
         }
-        
+
         Button btnCancel = new Button(_("Don't Paste"));
         Button btnIgnore = new Button(_("Paste Anyway"));
         btnIgnore.getStyleContext().addClass("destructive-action");

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -964,8 +964,8 @@ private:
                 vte.getCursorPosition(cursorCol, cursorRow);
                 //tracef("\trow=%d, column=%d",cursorRow,cursorCol);
                 if (cursorRow > 0 || cursorCol >0) {
-                    trace("Warning VTE Configuration");
-                    tilix.warnVTEConfigIssue();
+                    trace("Scheduling VTE configuration warning");
+                    tilix.setShouldWarnVTEConfigIssue(true);
                 }
             }
             // Update initialized state after initial content change to give prompt_command a chance to kick in


### PR DESCRIPTION
Hi!
On first run, Tilix shows a warning dialog on VTE configuration issues on a lot of distributions ( https://gnunn1.github.io/tilix-web/manual/vteconfig/ )

Since Tilix is the default terminal emulator on a couple of
distributions (PureOS, Budgie, ...), throwing a warning message into the user's face is not a
great initial experience. This also applies to cases where Tilix is not the default, of course.
So, those distributions would disable the warning message, which is also
not great, because it hides an issue. Changing the VTE configuration distribution-wide is also not an option most of the time.

This PR implements a compromise of these positions: Tilix will not show the warning message when it is run, but instead when the user opens the preferences dialog.
This should be reasonable, because users wondering about the drawbacks of the VTE (mis)configuration like the folder name not being remembered when splitting terminals will go to Tilix' preferences first and then see the issue.
Most other user who just want to use a terminal right now, won't see the warning.

This should prevent us at PureOS in particular from disabling the message completely.
Thank you for considering!