### PR TITLE
Fixes #1458

### DIFF
--- a/data/nautilus/open-tilix.py
+++ b/data/nautilus/open-tilix.py
@@ -37,7 +37,7 @@ def open_terminal(uri):
             value = "{0} -p {1}".format(value, file_obj.port)
         if Nautilus.FileInfo.create_for_uri(uri).is_directory():
             _dir = unquote(file_obj.path).replace(" ", "\ ")
-            value = '{0} cd "{1}" ; $SHELL'.format(value, _dir)
+            value = '{0} "cd {1}" ; $SHELL'.format(value, _dir)
         call('{0} -e "{1}" &'.format(TERMINAL, value), shell=True)
     elif file_obj.scheme == "file":
         filename = Gio.File.new_for_uri(uri).get_path()

--- a/data/nautilus/open-tilix.py
+++ b/data/nautilus/open-tilix.py
@@ -35,9 +35,9 @@ def open_terminal(uri):
             value = 'ssh -t {0}'.format(file_obj.hostname)
         if file_obj.port:
             value = "{0} -p {1}".format(value, file_obj.port)
-        _dir = path.dirname(unquote(file_obj.path)).replace(" ", "\ ")
-        value = '{0} cd "{1}" ; $SHELL'.format(value, _dir)
-
+        if Nautilus.FileInfo.create_for_uri(uri).is_directory():
+            _dir = unquote(file_obj.path).replace(" ", "\ ")
+            value = '{0} cd "{1}" ; $SHELL'.format(value, _dir)
         call('{0} -e "{1}" &'.format(TERMINAL, value), shell=True)
     elif file_obj.scheme == "file":
         filename = Gio.File.new_for_uri(uri).get_path()

--- a/data/nautilus/open-tilix.py
+++ b/data/nautilus/open-tilix.py
@@ -10,7 +10,7 @@ try:
     from urlparse import urlparse
 except ImportError:
     from urllib.parse import unquote, urlparse
-
+from os import path
 
 from gi import require_version
 require_version('Gtk', '3.0')
@@ -25,11 +25,26 @@ REMOTE_URI_SCHEME = ['ftp', 'sftp']
 textdomain("tilix")
 
 
-def open_terminal_in_file(filename):
-    if filename:
-        call('{0} -w "{1}" &'.format(TERMINAL, filename), shell=True)
-    else:
-        call("{0} &".format(TERMINAL), shell=True)
+def open_terminal(uri):
+    file_obj = urlparse(uri)
+    if file_obj.scheme in REMOTE_URI_SCHEME:
+        if file_obj.username:
+            value = 'ssh -t {0}@{1}'.format(file_obj.username,
+                                            file_obj.hostname)
+        else:
+            value = 'ssh -t {0}'.format(file_obj.hostname)
+        if file_obj.port:
+            value = "{0} -p {1}".format(value, file_obj.port)
+        _dir = path.dirname(unquote(file_obj.path)).replace(" ", "\ ")
+        value = '{0} cd "{1}" ; $SHELL'.format(value, _dir)
+
+        call('{0} -e "{1}" &'.format(TERMINAL, value), shell=True)
+    elif file_obj.scheme == "file":
+        filename = Gio.File.new_for_uri(uri).get_path()
+        if filename:
+            call('{0} -w "{1}" &'.format(TERMINAL, filename), shell=True)
+        else:
+            call("{0} &".format(TERMINAL), shell=True)
 
 
 class OpenTilixShortcutProvider(GObject.GObject,
@@ -60,8 +75,7 @@ class OpenTilixShortcutProvider(GObject.GObject,
             self._create_accel_group()
 
     def _open_terminal(self, *args):
-        filename = unquote(self._uri[7:])
-        open_terminal_in_file(filename)
+        open_terminal(self._uri)
 
     def get_widget(self, uri, window):
         self._uri = uri
@@ -75,30 +89,8 @@ class OpenTilixShortcutProvider(GObject.GObject,
 
 class OpenTilixExtension(GObject.GObject, Nautilus.MenuProvider):
 
-    def _open_terminal(self, file_):
-        if file_.get_uri_scheme() in REMOTE_URI_SCHEME:
-            result = urlparse(file_.get_uri())
-            if result.username:
-                value = 'ssh -t {0}@{1}'.format(result.username,
-                                                result.hostname)
-            else:
-                value = 'ssh -t {0}'.format(result.hostname)
-            if result.port:
-                value = "{0} -p {1}".format(value, result.port)
-            if file_.is_directory():
-                _dir = unquote(result.path).replace(" ", "\ ")
-                value = '{0} cd "{1}" ; $SHELL'.format(value, _dir)
-
-            call('{0} -e "{1}" &'.format(TERMINAL, value), shell=True)
-        else:
-            filename = Gio.File.new_for_uri(file_.get_uri()).get_path()
-            open_terminal_in_file(filename)
-
-    def _menu_activate_cb(self, menu, file_):
-        self._open_terminal(file_)
-
-    def _menu_background_activate_cb(self, menu, file_):
-        self._open_terminal(file_)
+    def _menu_activate(self, menu, file_):
+        open_terminal(file_.get_uri())
 
     def get_file_items(self, window, files):
         if len(files) != 1:
@@ -115,14 +107,14 @@ class OpenTilixExtension(GObject.GObject, Nautilus.MenuProvider):
                 item = Nautilus.MenuItem(name='NautilusPython::open_remote_item',
                                          label=_(u'Open Remote Tilix'),
                                          tip=_(u'Open Remote Tilix In {}').format(uri))
-                item.connect('activate', self._menu_activate_cb, file_)
+                item.connect('activate', self._menu_activate, file_)
                 items.append(item)
 
             filename = file_.get_name().decode('utf-8')
             item = Nautilus.MenuItem(name='NautilusPython::open_file_item',
                                      label=_(u'Open In Tilix'),
                                      tip=_(u'Open Tilix In {}').format(filename))
-            item.connect('activate', self._menu_activate_cb, file_)
+            item.connect('activate', self._menu_activate, file_)
             items.append(item)
 
         return items
@@ -133,12 +125,12 @@ class OpenTilixExtension(GObject.GObject, Nautilus.MenuProvider):
             item = Nautilus.MenuItem(name='NautilusPython::open_bg_remote_item',
                                      label=_(u'Open Remote Tilix Here'),
                                      tip=_(u'Open Remote Tilix In This Directory'))
-            item.connect('activate', self._menu_activate_cb, file_)
+            item.connect('activate', self._menu_activate, file_)
             items.append(item)
 
         item = Nautilus.MenuItem(name='NautilusPython::open_bg_file_item',
                                  label=_(u'Open Tilix Here'),
                                  tip=_(u'Open Tilix In This Directory'))
-        item.connect('activate', self._menu_background_activate_cb, file_)
+        item.connect('activate', self._menu_activate, file_)
         items.append(item)
         return items


### PR DESCRIPTION
The issue was due to 
```python
value = '{0} cd "{1}" ; $SHELL'.format(value, result.path)
```
The value of `result.path` is now passed to `unquote` function before. And the spaces also have a \ before so it works correctly on the terminal.
Tried that on my personal FTP server and everything works correctly. 