### PR TITLE
UnsafePasteDialog: Make sure pasted command fits on the prompt

### DIFF
--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -4330,6 +4330,7 @@ public:
         Label lblCmd = new Label(SimpleXML.markupEscapeText(cmd, cmd.length));
         lblCmd.setUseMarkup(true);
         lblCmd.setHalign(Align.START);
+        lblCmd.setEllipsize(PangoEllipsizeMode.END);
 
         if (count(cmd,"\n") > 6) {
             ScrolledWindow sw = new ScrolledWindow();


### PR DESCRIPTION
See https://twitter.com/BabyWogue/status/1075527836612612096

Before the patch, the app crashes on Wayland/X11
```
(tilix:7412): Gdk-CRITICAL **: 00:22:11.876: gdkdisplay-wayland.c:1402: Unable to create Cairo image surface: invalid value (typically too big) for the size of the input (surface, pattern, etc.)
fish: “tilix” terminated by signal SIGSEGV (Address boundary error)
```

Results after the patch
![screenshot from 2018-12-20 00-31-10](https://user-images.githubusercontent.com/7660997/50254559-c7298e80-03ee-11e9-9402-45bf92e8c56b.png)

Doesn't happen anymore on Wayland.