### PR TITLE
Fix signal handler id data type

### DIFF
--- a/source/gx/tilix/sidebar.d
+++ b/source/gx/tilix/sidebar.d
@@ -470,8 +470,8 @@ private:
     EventBox evNotification;
     AspectFrame afNotification;
 
-    size_t[] ebEventHandlerId;
-    size_t closeButtonHandler;
+    gulong[] ebEventHandlerId;
+    gulong closeButtonHandler;
 
     bool isRootWindow = false;
 


### PR DESCRIPTION
Correctly use gulong instead of size_t as per
https://developer.gnome.org/gobject/stable/gobject-Signals.html

This fixes the build on aarch64.