### PR TITLE
Meson: validate appdata without network access

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -36,7 +36,7 @@ if appstream_util.found()
   test (
     'Validate appdata file',
     appstream_util,
-    args: ['validate-relax', join_paths(meson.current_build_dir (), '@0@.appdata.xml'.format(meson.project_name()))]
+    args: ['validate-relax', '--nonet', join_paths(meson.current_build_dir (), '@0@.appdata.xml'.format(meson.project_name()))]
   )
 endif
 


### PR DESCRIPTION
Currently, we validate the appata file using appstream-util which requires network access to fetch the screenshots and validate them. 
A lot of distros out there run tests without network access, this will make the appdata test fail and they might patch Tilix downstream.