### PR TITLE
Avoid calling `values()` on a shared object

### DIFF
--- a/source/gx/tilix/terminal/monitor.d
+++ b/source/gx/tilix/terminal/monitor.d
@@ -43,7 +43,7 @@ private:
 
     bool fireEvents() {
         synchronized {
-            foreach(process; processes.values()) {
+            foreach(process; processes) {
                 if (process.eventType != MonitorEventType.NONE) {
                     onChildProcess.emit(process.eventType, process.gpid, process.activePid, process.activeName);
                     process.eventType = MonitorEventType.NONE;
@@ -138,7 +138,7 @@ void monitorProcesses(int sleep, Tid tid) {
             // all open terminals. We need to get these using shell
             // PID and will store them to raise events for each terminal.
             auto activeProcesses = getActiveProcessList();
-            foreach(process; processes.values()) {
+            foreach(process; processes) {
                 auto activeProcess  = activeProcesses.get(process.gpid, null);
                 // No need to raise event for same process.
                 if (activeProcess !is null && activeProcess.pid != process.activePid) {


### PR DESCRIPTION
* This fixes a compilation on dmd v2.087.0+ ( I think? )
  /usr/include/dmd/druntime/import/object.d(3453,36): Error: cannot implicitly convert expression aa of type shared(ProcessStatus[int]) to const(shared(ProcessStatus)[int])
  source/gx/tilix/terminal/monitor.d(46,46): Error: template instance `object.values!(shared(ProcessStatus[int]), shared(ProcessStatus), int)` error instantiating