### PR TITLE
Gives every tab the ${title}

### DIFF
--- a/data/gsettings/com.gexperts.Tilix.gschema.xml
+++ b/data/gsettings/com.gexperts.Tilix.gschema.xml
@@ -203,7 +203,7 @@
       <description>If true, a prompt is shown confirming the deletion of a profile.</description>
     </key>
     <key name="session-name" type="s">
-      <default>'Default'</default>
+      <default>${title}</default>
       <summary>The default name to use for a session</summary>
       <description>The default name of the session, terminal variables can be used in which case the active terminal resolves the variables.</description>
     </key>

--- a/data/gsettings/com.gexperts.Tilix.gschema.xml
+++ b/data/gsettings/com.gexperts.Tilix.gschema.xml
@@ -203,7 +203,7 @@
       <description>If true, a prompt is shown confirming the deletion of a profile.</description>
     </key>
     <key name="session-name" type="s">
-      <default>${title}</default>
+      <default>'${title}'</default>
       <summary>The default name to use for a session</summary>
       <description>The default name of the session, terminal variables can be used in which case the active terminal resolves the variables.</description>
     </key>


### PR DESCRIPTION
When using tab mode it is helpful to distinguish the different tabs properly e.g. by seeing at first glance what user host or directory is actually used on the shell. Using the ${title} variable ensures that you hit the right tab when you have multiple sessions. Without this patch every tab just shows the text 'Default'.