### PR TITLE
bug fix: invert the condition when checking for PREFIX

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 # Determine PREFIX.
 if [ -z "$1" ]; then
-    if [ -n "$PREFIX" ]; then
+    if [ -z "$PREFIX" ]; then
         PREFIX='/usr'
     fi
 else


### PR DESCRIPTION
Alternative implementation:

```bash
export PREFIX="${1:-${PREFIX:-/usr}}"
```

This is [portable](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02):

> ${_parameter_:-**[**_word_**]**}
> **Use Default Values**. If _parameter_ is unset or null, the expansion of _word_ (or an empty string if _word_ is omitted) shall be substituted; otherwise, the value of _parameter_ shall be substituted.

For people familiar with this construct the code is much easier to read. It's obvious at the first glance that `$1`, `$PREFIX` and `/usr` are considered in this order.