### PR TITLE
Add shortcut to "Unselect all"

### DIFF
--- a/data/gsettings/com.gexperts.Tilix.gschema.xml
+++ b/data/gsettings/com.gexperts.Tilix.gschema.xml
@@ -1187,6 +1187,10 @@
       <default>'&lt;Ctrl&gt;&lt;Shift&gt;a'</default>
       <summary>Keyboard shortcut to select all text in terminal</summary>
     </key>
+    <key name="terminal-unselect-all" type="s">
+      <default>'disabled'</default>
+      <summary>Keyboard shortcut to unselect all text in terminal</summary>
+    </key>
     <key name="terminal-zoom-in" type="s">
       <default>'&lt;Ctrl&gt;plus'</default>
       <summary>Keyboard shortcut to make font larger</summary>

--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -431,6 +431,12 @@
                 <property name="title" translatable="yes" context="shortcut window">Select all</property>
               </object>
             </child>
+            <child>
+              <object class="GtkShortcutsShortcut" id ="terminal-unselect-all">
+                <property name="visible">1</property>
+                <property name="title" translatable="yes" context="shortcut window">Unselect all</property>
+              </object>
+            </child>
           </object>
         </child>
         <child>

--- a/source/gx/tilix/terminal/actions.d
+++ b/source/gx/tilix/terminal/actions.d
@@ -25,6 +25,7 @@ enum ACTION_ADVANCED_PASTE = "advanced-paste";
 enum ACTION_COPY_LINK = "copy-link";
 enum ACTION_OPEN_LINK = "open-link";
 enum ACTION_SELECT_ALL = "select-all";
+enum ACTION_UNSELECT_ALL = "unselect-all";
 enum ACTION_ZOOM_IN = "zoom-in";
 enum ACTION_ZOOM_OUT = "zoom-out";
 enum ACTION_ZOOM_NORMAL = "zoom-normal";

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -575,6 +575,7 @@ private:
 
 
         registerActionWithSettings(group, ACTION_PREFIX, ACTION_SELECT_ALL, gsShortcuts, delegate(GVariant, SimpleAction) { vte.selectAll(); });
+        registerActionWithSettings(group, ACTION_PREFIX, ACTION_UNSELECT_ALL, gsShortcuts, delegate(GVariant, SimpleAction) { vte.unselectAll(); });
 
         //Link Actions, no shortcuts, context menu only
         registerAction(group, ACTION_PREFIX, ACTION_COPY_LINK, null, delegate(GVariant, SimpleAction) {


### PR DESCRIPTION
This adds the option to bind a keyboard shortcut to "Unselect All", fixing #1801.  The state is set to `disabled` by default rather than trying to find an available and appropriate key binding.

This doesn't add a corresponding "Unselect All" option to the context menu which is easy enough to do but I couldn't find an inverse icon for `edit-select-all-symbolic`.