### PR TITLE
Avoid messing the previous exit code

### DIFF
--- a/data/scripts/tilix_int.sh
+++ b/data/scripts/tilix_int.sh
@@ -43,7 +43,9 @@ __tilix_urlencode() (
 )
 
 __tilix_osc7() (
+  local previous_exit_status=$?
   printf "\033]7;file://%s%s\007" "${HOSTNAME:-}" "$(__tilix_urlencode "${PWD}")"
+  return $previous_exit_status
 )
 
 if [[ $PROMPT_COMMAND != *"__vte_prompt_command"* ]]


### PR DESCRIPTION
The function ` __tilix_osc7()` in the `scripts/tilix_int.sh` script overrides the previous command exit code (when calling the`printf` command), so some tools that render custom prompts, like [Bash-it](https://github.com/Bash-it/bash-it), or [Starship](https://github.com/starship/starship) can't show the correct value.

This PR fixes it.