### PR TITLE
[meson] add yaru scheme to install_data

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -79,6 +79,7 @@ install_data(
         'schemes/solarized-dark.json',
         'schemes/solarized-light.json',
         'schemes/tango.json',
+        'schemes/yaru.json',
     ],
     install_dir: pkgdatadir / 'schemes'
 )


### PR DESCRIPTION
yaru.json is missing from data/meson.build and so it is not istalled.

Closes #1926