### PR TITLE
Add possibility to configure always enabled regex

### DIFF
--- a/data/gsettings/com.gexperts.Tilix.gschema.xml
+++ b/data/gsettings/com.gexperts.Tilix.gschema.xml
@@ -314,6 +314,11 @@
       <summary>Whether to match using regular expressions</summary>
       <description>If true, the search will be done treating the search text as a regular expression.</description>
     </key>
+    <key name="always-use-regex-in-search" type="b">
+        <default>false</default>
+        <summary>Whether regex option is always enabled in search dialog</summary>
+        <description>If true, search will always be done using regex.</description>
+    </key>
     <key name="search-default-wrap-around" type="b">
       <default>true</default>
       <summary>Whether searches wrap the terminal buffer</summary>

--- a/source/gx/tilix/prefeditor/prefdialog.d
+++ b/source/gx/tilix/prefeditor/prefdialog.d
@@ -1528,6 +1528,11 @@ private:
         bh.bind(SETTINGS_CONTROL_CLICK_TITLE_KEY, cbControlClickTitle, "active", GSettingsBindFlags.DEFAULT);
         add(cbControlClickTitle);
 
+        //always use regex when searching
+        CheckButton cbAlwaysUseRegex = new CheckButton(_("Always use regex in search dialog"));
+        bh.bind(SETTINGS_ALWAYS_USE_REGEX_IN_SEARCH, cbAlwaysUseRegex, "active", GSettingsBindFlags.DEFAULT);
+        add(cbAlwaysUseRegex);
+
         //Closing of last session closes window
         CheckButton cbCloseWithLastSession = new CheckButton(_("Close window when last session is closed"));
         bh.bind(SETTINGS_CLOSE_WITH_LAST_SESSION_KEY, cbCloseWithLastSession, "active", GSettingsBindFlags.DEFAULT);

--- a/source/gx/tilix/preferences.d
+++ b/source/gx/tilix/preferences.d
@@ -98,6 +98,8 @@ enum SETTINGS_SEARCH_DEFAULT_MATCH_ENTIRE_WORD = "search-default-match-entire-wo
 enum SETTINGS_SEARCH_DEFAULT_MATCH_AS_REGEX = "search-default-match-as-regex";
 enum SETTINGS_SEARCH_DEFAULT_WRAP_AROUND = "search-default-wrap-around";
 
+enum SETTINGS_ALWAYS_USE_REGEX_IN_SEARCH = "always-use-regex-in-search";
+
 enum SETTINGS_BACKGROUND_IMAGE_KEY = "background-image";
 enum SETTINGS_BACKGROUND_IMAGE_SCALE_KEY = "background-image-scale";
 enum SETTINGS_BACKGROUND_IMAGE_MODE_KEY = "background-image-mode";

--- a/source/gx/tilix/terminal/search.d
+++ b/source/gx/tilix/terminal/search.d
@@ -206,7 +206,10 @@ private:
             }
             return;
         }
-        if (!matchAsRegex)
+
+        GSettings gsSettings = new GSettings(SETTINGS_ID);
+        bool alwaysUseRegex = gsSettings.getBoolean(SETTINGS_ALWAYS_USE_REGEX_IN_SEARCH);
+        if (!matchAsRegex && !alwaysUseRegex)
             text = GRegex.escapeString(text);
         if (entireWordOnly)
             text = format("\\b%s\\b", text);


### PR DESCRIPTION
Hello,

When I want to copy something from terminal (like a part of some output) I always use regex in search.
I believe many people also does this.

I thought it'd be really nice to be able to configure regex in search so it's always enabled.