### PR TITLE
keep quake window open if focus is restored before timeout has been reached

### DIFF
--- a/source/gx/gtk/threads.d
+++ b/source/gx/gtk/threads.d
@@ -152,7 +152,7 @@ void threadsAddIdleDelegate(T, parameterTuple...)(T theDelegate, parameterTuple 
  *
  * This code from grestful (https://github.com/Gert-dev/grestful)
  */
-void threadsAddTimeoutDelegate(T, parameterTuple...)(uint interval, T theDelegate, parameterTuple parameters)
+uint threadsAddTimeoutDelegate(T, parameterTuple...)(uint interval, T theDelegate, parameterTuple parameters)
 {
 	void* delegatePointer = null;
 
@@ -185,7 +185,7 @@ void threadsAddTimeoutDelegate(T, parameterTuple...)(uint interval, T theDelegat
 	// isn't used anymore and collects it.
 	GC.addRoot(delegatePointer);
 
-	gdk.Threads.threadsAddTimeout(
+	return gdk.Threads.threadsAddTimeout(
 		interval,
 		cast(GSourceFunc) &invokeDelegatePointerFunc!(DelegatePointer!(T, parameterTuple), int),
 		delegatePointer


### PR DESCRIPTION
Simply allow the focusOut timeout (that closes the quake window) to be cancelled and specifically cancel it in the focusIn event handler.

Fixes:
- https://github.com/gnunn1/tilix/issues/1658
- https://github.com/gnunn1/tilix/issues/1647

Relates to:
- https://github.com/gnunn1/tilix/issues/858