### PR TITLE
Add meson target for man page translations

### DIFF
--- a/data/man/meson.build
+++ b/data/man/meson.build
@@ -1,1 +1,25 @@
-install_man('tilix')
+install_man('tilix.1')
+
+po4a = find_program('po4a-translate', required: false)
+
+if po4a.found()
+
+    locales = [ 'ca', 'cs', 'de', 'en_GB', 'es', 'fr', 'hr',
+                'it', 'nb_NO', 'nl', 'oc', 'pl', 'pt_BR', 'pt',
+                'pt_PT', 'ro', 'ru', 'sr', 'tr', 'uk', 'zh_Hant' ]
+
+    foreach locale : locales
+        custom_target('man_' + locale,
+            output: locale,
+            input: [ 'tilix.1', 'po/' + locale + '.man.po' ],
+            command: [ po4a, '--keep', '0',
+                             '--format', 'man',
+                             '--master', '@INPUT0@',
+                             '--po', '@INPUT1@',
+                             '--localized', '@OUTPUT@/man1/tilix.1'],
+            install: true,
+            install_dir: get_option('mandir')
+        )
+    endforeach
+
+endif

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,3 +1,4 @@
+subdir('man')
 
 # install the icons
 install_data(
@@ -19,9 +20,6 @@ desktop_file = i18n.merge_file(
     install: true,
     install_dir: appdir
 )
-
-# Install manual page
-install_man(['man/tilix.1'])
 
 # Validate desktop file
 desktop_file_validate = find_program('desktop-file-validate', required: false)


### PR DESCRIPTION
Add a new meson custom which allows to generate and install man page
translations using `meson build` and `meson install` when po4a is
available.

This is a naive conversion of install-man-pages.sh.