### PR TITLE
more appdata -> metainfo move

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ tilix.gresource
 data/pkg/arch/pkg
 data/pkg/arch/src
 data/pkg/desktop/com.gexperts.Tilix.desktop
-data/appdata/com.gexperts.Tilix.appdata.xml
+data/metainfo/com.gexperts.Tilix.appdata.xml
 data/man/man
 *.pkg.tar.xz
 *~

--- a/install.sh
+++ b/install.sh
@@ -94,10 +94,10 @@ fi
 desktop-file-validate data/pkg/desktop/com.gexperts.Tilix.desktop
 
 # Generate appdata file, requires xgettext 0.19.7
-msgfmt --xml --template=data/appdata/com.gexperts.Tilix.appdata.xml.in -d po -o data/appdata/com.gexperts.Tilix.appdata.xml
+msgfmt --xml --template=data/metainfo/com.gexperts.Tilix.appdata.xml.in -d po -o data/metainfo/com.gexperts.Tilix.appdata.xml
 if [ $? -ne 0 ]; then
     echo "Note that localizating appdata requires xgettext 0.19.7 or later, copying instead"
-    cp data/appdata/com.gexperts.Tilix.appdata.xml.in data/appdata/com.gexperts.Tilix.appdata.xml
+    cp data/metainfo/com.gexperts.Tilix.appdata.xml.in data/metainfo/com.gexperts.Tilix.appdata.xml
 fi
 
 # Copying Nautilus extension
@@ -123,7 +123,7 @@ cd ../../..
 install -Dm 755 tilix -t "$PREFIX/bin/"
 
 install -Dm 644 data/pkg/desktop/com.gexperts.Tilix.desktop -t "$PREFIX/share/applications/"
-install -Dm 644 data/appdata/com.gexperts.Tilix.appdata.xml -t "$PREFIX/share/metainfo/"
+install -Dm 644 data/metainfo/com.gexperts.Tilix.appdata.xml -t "$PREFIX/share/metainfo/"
 
 # Update icon cache if Prefix is /usr
 if [ "$PREFIX" = '/usr' ] || [ "$PREFIX" = "/usr/local" ]; then


### PR DESCRIPTION
A follow up to https://github.com/gnunn1/tilix/commit/51d0f8b09a0ec5575bb3d2e58d758a8539c9e549

Building this project without these changes created these error messages:

```plaintext
sudo ./install.sh
.....
Processing po/zh_CN.po
Processing po/zh_TW.po
msgfmt: cannot read data/appdata/com.gexperts.Tilix.appdata.xml.in: failed to load external entity "data/appdata/com.gexperts.Tilix.appdata.xml.in"

msgfmt: cannot read data/appdata/com.gexperts.Tilix.appdata.xml.in: failed to load external entity "data/appdata/com.gexperts.Tilix.appdata.xml.in"

msgfmt: cannot read data/appdata/com.gexperts.Tilix.appdata.xml.in: failed to load external entity "data/appdata/com.gexperts.Tilix.appdata.xml.in"

msgfmt: cannot read data/appdata/com.gexperts.Tilix.appdata.xml.in: failed to load external entity "data/appdata/com.gexperts.Tilix.appdata.xml.in"

msgfmt: cannot read data/appdata/com.gexperts.Tilix.appdata.xml.in: failed to load external entity "data/appdata/com.gexperts.Tilix.appdata.xml.in"

msgfmt: cannot locate ITS rules for data/appdata/com.gexperts.Tilix.appdata.xml.in
```


Full disclosure I have no idea what I'm really doing here, but it seemed like this was the right change. ¯\_(ツ)_/¯

This terminal is awesome, and I just wanted it to work on Fedora 33 :tada: - it seems like the currently released package is broken, and for reasons that are mostly out of your control, and for that I am sorry!