### PR TITLE
Workaround for getting un-fullscreened on dialog

### DIFF
--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -1438,10 +1438,18 @@ private:
         string pasteText = Clipboard.get(source).waitForText();
         if (pasteText.length == 0) return;
 
-        AdvancedPasteDialog dialog = new AdvancedPasteDialog(cast(Window) getToplevel(), pasteText, isPasteUnsafe(pasteText));
+        Window parent = cast(Window) getToplevel();
+        AdvancedPasteDialog dialog = new AdvancedPasteDialog(parent, pasteText, isPasteUnsafe(pasteText));
+        bool wasFullscreen = false;
+        if (parent.getWindow() !is null && ((parent.getWindow().getState() & GdkWindowState.FULLSCREEN) == GdkWindowState.FULLSCREEN)) {
+            wasFullscreen = true;
+        }
         scope(exit) {
             dialog.hide();
             dialog.destroy();
+            if (wasFullscreen) {
+                parent.fullscreen();
+            }
         }
         dialog.showAll();
         if (dialog.run() == ResponseType.APPLY) {


### PR DESCRIPTION
Dialog show of advanced paste and preferences cause fullscreen to exit for unknown reason.  
Make it fullscreen again if it was fullscreen, so that it's less annoying.