### PR TITLE
Update flatpak manifest

### DIFF
--- a/experimental/flatpak/com.gexperts.Tilix.yaml
+++ b/experimental/flatpak/com.gexperts.Tilix.yaml
@@ -1,8 +1,11 @@
 id: com.gexperts.Tilix
 branch: master
 runtime: org.gnome.Platform
-runtime-version: '3.30'
+runtime-version: '3.34'
 sdk: org.gnome.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.ldc
+  - org.freedesktop.Sdk.Extension.dmd
 command: tilix
 finish-args:
   - --share=ipc
@@ -17,19 +20,22 @@ finish-args:
   - --talk-name=org.freedesktop.secrets
   - --device=all
 cleanup:
-  # - '/bin/ldc*'
-  # - '/bin/ldmd2'
-  - '/bin/dmd*'
+  - '/bin/appstreamcli'
+  - '/bin/ncurses6-config'
   - '/bin/po4a*'
   - '/bin/vte*'
-  - '/ldc-0.17'
+  - '/etc/appstream.conf'
   - '/etc/bash_completion.d'
   - '/include'
   - '/lib/cmake'
   - '/lib/debug'
+  - '/lib/libappstream.*'
+  - '/lib/libstemmer.*'
+  - '/lib/libyaml*'
   - '/lib/pkgconfig'
   - '/share/gtk-doc'
   - '/share/man'
+  - '/share/metainfo'
   - '/src'
   - '*.la'
   - '*.a'
@@ -63,63 +69,19 @@ modules:
       - type: archive
         url: https://thrysoee.dk/editline/libedit-20181209-3.1.tar.gz
         sha256: 2811d70c0b000f2ca91b7cb1a37203134441743c4fcc9c37b0b687f328611064
-  - name: ldc-0.17
-    buildsystem: cmake-ninja
-    config-opts:
-      - '-DCMAKE_SYSTEM_PREFIX_PATH=/app'
-      - '-DCMAKE_INSTALL_PREFIX:PATH=/app/ldc-0.17'
-    sources:
-      - type: archive
-        url: https://github.com/ldc-developers/ldc/releases/download/v0.17.5/ldc-0.17.5-src.tar.gz
-        sha256: 7aa540a135f9fa1ee9722cad73100a8f3600a07f9a11d199d8be68887cc90008
-      - type: patch
-        path: disable-ldc-completions.patch
-  - name: dmd
-    buildsystem: simple
-    build-commands:
-      - 'make -j2 -C dmd -f posix.mak install HOST_DMD=/app/ldc-0.17/bin/ldmd2 INSTALL_DIR=$PWD/install'
-      - 'make -j2 -C phobos -f posix.mak install INSTALL_DIR=$PWD/install'
-      - 'cp -rv install/linux/bin* /app/bin'
-      - 'cp -v dmd.conf /app/bin'
-      - 'cp -rv install/linux/lib* /app'
-      - 'install -d /app/src'
-      - 'cp -rv druntime phobos /app/src'
-    sources:
-      - type: git
-        url: https://github.com/dlang/dmd
-        tag: v2.081.1
-        dest: dmd
-      - type: git
-        url: https://github.com/dlang/druntime
-        tag: v2.081.1
-        dest: druntime
-      - type: git
-        url: https://github.com/dlang/tools
-        tag: v2.081.1
-        dest: tools
-      - type: git
-        url: https://github.com/dlang/phobos
-        tag: v2.081.1
-        dest: phobos
-      - type: file
-        path: dmd.conf
-  # - name: ldc
-  #   buildsystem: cmake-ninja
-  #   config-opts:
-  #     - '-DD_COMPILER=/app/ldc-0.17/bin/ldmd2'
-  #   sources:
-  #     - type: archive
-  #       url: https://github.com/ldc-developers/ldc/releases/download/v1.11.0-beta2/ldc-1.11.0-beta2-src.tar.gz
-  #       sha256: 49ef9009238859275e80afa20ee6d37b6797a1b2b41923a2a5922b6381efb14c
   - name: gtkd
     buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/dmd/bin
     build-commands:
       - 'make -j2 prefix=/app install-gtkd install-vte'
     sources:
       - type: archive
-        url: https://gtkd.org/Downloads/sources/GtkD-3.8.4.zip
-        sha256: b9686f30c48df58909c9845dcf7fb6a40745e47b6db412f8eb9ad2c655fd6136
+        url: https://gtkd.org/Downloads/sources/GtkD-3.9.0.zip
+        sha512: f8b8a7b83a23af990abb77f16e4bddf2f72bb65ad210ff8f138b0d4ff66fb5fb2a73a3cbe868a8d2ecf3abf98ece5af771af63068dc2fbf8668e46039320cf0f
         strip-components: 0
+      - type: patch
+        path: gtkd3-pkgconfig.patch
   - name: po4a
     buildsystem: simple
     build-commands:
@@ -133,6 +95,14 @@ modules:
       - type: archive
         url: https://github.com/mquinson/po4a/releases/download/v0.54/po4a-0.54.tar.gz
         sha256: 596f7621697f9dd12709958c229e256b56683d25997ac73c9625a2cc0c603d51
+# TODO: Use shared module from flathub.
+  - name: intltool
+    cleanup:
+      - "*"
+    sources:
+      - type: archive
+        url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+        sha512: 4c93cb26592ed0b1622d3b7800b5d6622ffa36f58ac73f2ef0bddfab522565fdfb8fa73d81914b9a202f1d62bc995a08960f8adb9f62c86918e75498e85fbfdf
   - name: libvte-patched
     buildsystem: autotools
     config-opts:
@@ -140,19 +110,69 @@ modules:
       - '--disable-vala'
     sources:
       - type: archive
-        url: https://ftp.gnome.org/pub/GNOME/sources/vte/0.53/vte-0.53.0.tar.xz
+        url: https://download.gnome.org/sources/vte/0.53/vte-0.53.0.tar.xz
         sha256: c319eb34e9c64c78cd4940cde0892bd18784bcdcaaa7a23a9c8ec6052317a130
       - type: patch
         path: vte291-command-notify-scroll-speed.patch
+      - type: patch
+        path: vte291-exceptions-gcc811.patch
   - name: toolbox
     buildsystem: simple
     build-commands:
-      - 'gcc -static -o /app/bin/tilix-flatpak-toolbox tilix-flatpak-toolbox.c'
+      - 'gcc -o /app/bin/tilix-flatpak-toolbox tilix-flatpak-toolbox.c'
     sources:
       - type: file
         path: tilix-flatpak-toolbox.c
+  - name: yaml
+    sources:
+      - type: archive
+        url: https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz
+        sha512: dadd7d8e0d88b5ebab005e5d521d56d541580198aa497370966b98c904586e642a1cd4f3881094eb57624f218d50db77417bbfd0ffdce50340f011e35e8c4c02
+  - name: lmdb
+    buildsystem: simple
+    subdir: libraries/liblmdb
+    build-commands:
+      - 'sed -i s~/usr/local~/app~ Makefile'
+      - 'make -j $FLATPAK_BUILDER_N_JOBS'
+      - 'make install'
+      - 'rm /app/lib/liblmdb.a'
+    sources:
+      - type: git
+        url: https://github.com/LMDB/lmdb.git
+        tag: LMDB_0.9.29
+        commit: 8ad7be2510414b9506ec9f9e24f24d04d9b04a1a
+    cleanup:
+      - '/bin'
+      - '/include'
+      - '/lib/debug'
+      - '/share'
+  - name: stemmer
+    buildsystem: simple
+    build-commands:
+      - 'make libstemmer.so -j$FLATPAK_BUILDER_N_JOBS'
+      - 'install -Dm644 include/libstemmer.h /app/include/libstemmer.h'
+      - 'install -Dm644 libstemmer.so.0.0.0 /app/lib/libstemmer.so.0.0.0'
+      - 'ln -s libstemmer.so.0.0.0 /app/lib/libstemmer.so.0'
+      - 'ln -s libstemmer.so.0 /app/lib/libstemmer.so'
+    sources:
+      - type: git
+        url: https://github.com/snowballstem/snowball.git
+        commit: d29510ae32702a81cdc29177a133e894df854550
+      - type: patch
+        path: stemmer-dynlib.patch
+  - name: appstream
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/ximion/appstream.git
+    cleanup:
+      - '/share/doc'
+      - '/share/gettext'
+      - '/share/installed-tests'
   - name: tilix
     buildsystem: meson
+    build-options:
+      append-path: /usr/lib/sdk/dmd/bin
     sources:
       - type: git
         url: https://github.com/gnunn1/tilix.git

--- a/experimental/flatpak/gtkd3-pkgconfig.patch
+++ b/experimental/flatpak/gtkd3-pkgconfig.patch
@@ -1,0 +1,112 @@
+From a9db09117ab27127ca4c3b8d2f308fae483a9199 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Filipe=20La=C3=ADns?= <filipe.lains@gmail.com>
+Date: Fri, 7 Jun 2019 15:21:44 +0100
+Subject: [PATCH] makefile: fix install path for pkconfig files (#273)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+3742eda70ca3e045b6f513a57082d3487c97abe1 introduced a wrong behavior
+where the install commands for pkgconfig files were blindly ignoring
+$(prefix). This obviously breaks the build and introduces the
+possibility of the pkgconfig files not being installed to the system
+at all since $(libdir) is not suposed to have a leading /, that is
+$(prefix)'s job. All this resulted in a bad makefile being shipped
+in the 3.9.0 release.
+
+Signed-off-by: Filipe Laíns <lains@archlinux.org>
+---
+ GNUmakefile | 26 +++++++++++++-------------
+ 1 file changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/GNUmakefile b/GNUmakefile
+index a5919f5ee..0f44b4c15 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -378,33 +378,33 @@ install-shared-peas: $(SONAME_PEASD) install-shared-gtkd
+ 
+ install-headers-gtkd: gtkd-$(MAJOR).pc
+ 	install -d $(DESTDIR)$(prefix)/include/d/gtkd-$(MAJOR)
+-	install -d $(DESTDIR)$(libdir)/pkgconfig
++	install -d $(DESTDIR)$(prefix)/$(libdir)/pkgconfig
+ 	(cd generated/gtkd;   echo $(SOURCES_GTKD)   | sed -e s,generated/gtkd/,,g   | xargs tar cf -) | (cd $(DESTDIR)$(prefix)/include/d/gtkd-$(MAJOR); tar xvf -)
+-	install -m 644 gtkd-$(MAJOR).pc $(DESTDIR)$(libdir)/pkgconfig
++	install -m 644 gtkd-$(MAJOR).pc $(DESTDIR)$(prefix)/$(libdir)/pkgconfig
+ 
+ install-headers-gtkdgl: gtkdgl-$(MAJOR).pc install-headers-gtkd
+ 	(cd generated/gtkdgl; echo $(SOURCES_GTKDGL) | sed -e s,generated/gtkdgl/,,g | xargs tar cf -) | (cd $(DESTDIR)$(prefix)/include/d/gtkd-$(MAJOR); tar xvf -)
+-	install -m 644 gtkdgl-$(MAJOR).pc $(DESTDIR)$(libdir)/pkgconfig
++	install -m 644 gtkdgl-$(MAJOR).pc $(DESTDIR)$(prefix)/$(libdir)/pkgconfig
+ 
+ install-headers-gtkdsv: gtkdsv-$(MAJOR).pc install-headers-gtkd
+ 	(cd generated/sourceview; echo $(SOURCES_GTKDSV) | sed -e s,generated/sourceview/,,g | xargs tar cf -) | (cd $(DESTDIR)$(prefix)/include/d/gtkd-$(MAJOR); tar xvf -)
+-	install -m 644 gtkdsv-$(MAJOR).pc $(DESTDIR)$(libdir)/pkgconfig
++	install -m 644 gtkdsv-$(MAJOR).pc $(DESTDIR)$(prefix)/$(libdir)/pkgconfig
+ 
+ install-headers-gstreamer: gstreamerd-$(MAJOR).pc install-headers-gtkd
+ 	(cd generated/gstreamer; echo $(SOURCES_GSTREAMERD) | sed -e s,generated/gstreamer/,,g | xargs tar cf -) | (cd $(DESTDIR)$(prefix)/include/d/gtkd-$(MAJOR); tar xvf -)
+-	install -m 644 gstreamerd-$(MAJOR).pc $(DESTDIR)$(libdir)/pkgconfig
++	install -m 644 gstreamerd-$(MAJOR).pc $(DESTDIR)$(prefix)/$(libdir)/pkgconfig
+ 
+ install-headers-vte: vted-$(MAJOR).pc install-headers-gtkd
+ 	(cd generated/vte; echo $(SOURCES_VTED) | sed -e s,generated/vte/,,g | xargs tar cf -) | (cd $(DESTDIR)$(prefix)/include/d/gtkd-$(MAJOR); tar xvf -)
+-	install -m 644 vted-$(MAJOR).pc $(DESTDIR)$(libdir)/pkgconfig
++	install -m 644 vted-$(MAJOR).pc $(DESTDIR)$(prefix)/$(libdir)/pkgconfig
+ 
+ install-headers-peas: peasd-$(MAJOR).pc install-headers-gtkd
+ 	(cd generated/peas; echo $(SOURCES_PEASD) | sed -e s,generated/peas/,,g | xargs tar cf -) | (cd $(DESTDIR)$(prefix)/include/d/gtkd-$(MAJOR); tar xvf -)
+-	install -m 644 peasd-$(MAJOR).pc $(DESTDIR)$(libdir)/pkgconfig
++	install -m 644 peasd-$(MAJOR).pc $(DESTDIR)$(prefix)/$(libdir)/pkgconfig
+ 
+ uninstall: uninstall-gtkdgl uninstall-gtkdsv uninstall-gstreamer uninstall-vte uninstall-peas
+ 	$(foreach dir,$(shell ls generated/gtkd)  , rm -rf $(DESTDIR)$(prefix)/include/d/gtkd-$(MAJOR)/$(dir))
+-	rm -f $(DESTDIR)$(libdir)/pkgconfig/gtkd-$(MAJOR).pc
++	rm -f $(DESTDIR)$(prefix)/$(libdir)/pkgconfig/gtkd-$(MAJOR).pc
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(LIBNAME_GTKD)
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(SONAME_GTKD)
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(SONAME_GTKD).$(SO_VERSION)
+@@ -412,7 +412,7 @@ uninstall: uninstall-gtkdgl uninstall-gtkdsv uninstall-gstreamer uninstall-vte u
+ 
+ uninstall-gtkdgl:
+ 	$(foreach dir,$(shell ls generated/gtkdgl), rm -rf $(DESTDIR)$(prefix)/include/d/gtkd-$(MAJOR)/$(dir))
+-	rm -f $(DESTDIR)$(libdir)/pkgconfig/gtkdgl-$(MAJOR).pc
++	rm -f $(DESTDIR)$(prefix)/$(libdir)/pkgconfig/gtkdgl-$(MAJOR).pc
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(LIBNAME_GTKDGL)
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(SONAME_GTKDGL)
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(SONAME_GTKDGL).$(SO_VERSION)
+@@ -420,7 +420,7 @@ uninstall-gtkdgl:
+ 
+ uninstall-gtkdsv:
+ 	$(foreach dir,$(shell ls generated/sourceview), rm -rf $(DESTDIR)$(prefix)/include/d/$(dir))
+-	rm -f $(DESTDIR)$(libdir)/pkgconfig/gtkdsv-$(MAJOR).pc
++	rm -f $(DESTDIR)$(prefix)/$(libdir)/pkgconfig/gtkdsv-$(MAJOR).pc
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(LIBNAME_GTKDSV)
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(SONAME_GTKDSV)
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(SONAME_GTKDSV).$(SO_VERSION)
+@@ -428,7 +428,7 @@ uninstall-gtkdsv:
+ 
+ uninstall-gstreamer:
+ 	$(foreach dir,$(shell ls generated/gstreamer), rm -rf $(DESTDIR)$(prefix)/include/d/gtkd-$(MAJOR)/$(dir))
+-	rm -f $(DESTDIR)$(libdir)/pkgconfig/gstreamerd-$(MAJOR).pc
++	rm -f $(DESTDIR)$(prefix)/$(libdir)/pkgconfig/gstreamerd-$(MAJOR).pc
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(LIBNAME_GSTREAMERD)
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(SONAME_GSTREAMERD)
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(SONAME_GSTREAMERD).$(SO_VERSION)
+@@ -436,7 +436,7 @@ uninstall-gstreamer:
+ 
+ uninstall-vte:
+ 	$(foreach dir,$(shell ls generated/vte), rm -rf $(DESTDIR)$(prefix)/include/d/gtkd-$(MAJOR)/$(dir))
+-	rm -f $(DESTDIR)$(libdir)/pkgconfig/vted-$(MAJOR).pc
++	rm -f $(DESTDIR)$(prefix)/$(libdir)/pkgconfig/vted-$(MAJOR).pc
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(LIBNAME_VTED)
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(SONAME_VTED)
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(SONAME_VTED).$(SO_VERSION)
+@@ -444,7 +444,7 @@ uninstall-vte:
+ 
+ uninstall-peas:
+ 	$(foreach dir,$(shell ls generated/peas), rm -rf $(DESTDIR)$(prefix)/include/d/gtkd-$(MAJOR)/$(dir))
+-	rm -f $(DESTDIR)$(libdir)/pkgconfig/peasd-$(MAJOR).pc
++	rm -f $(DESTDIR)$(prefix)/$(libdir)/pkgconfig/peasd-$(MAJOR).pc
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(LIBNAME_PEASD)
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(SONAME_PEASD)
+ 	rm -f $(DESTDIR)$(prefix)/$(libdir)/$(SONAME_PEASD).$(SO_VERSION)

--- a/experimental/flatpak/stemmer-dynlib.patch
+++ b/experimental/flatpak/stemmer-dynlib.patch
@@ -1,0 +1,39 @@
+diff --git c/GNUmakefile i/GNUmakefile
+index 1693f5a..b33a42e 100644
+--- c/GNUmakefile
++++ i/GNUmakefile
+@@ -112,10 +112,10 @@ C_OTHER_OBJECTS = $(C_OTHER_SOURCES:.c=.o)
+ JAVA_CLASSES = $(JAVA_SOURCES:.java=.class)
+ JAVA_RUNTIME_CLASSES=$(JAVARUNTIME_SOURCES:.java=.class)
+ 
+-CFLAGS=-O2 -W -Wall -Wmissing-prototypes -Wmissing-declarations
++CFLAGS=-O2 -fPIC -W -Wall -Wmissing-prototypes -Wmissing-declarations
+ CPPFLAGS=-Iinclude
+ 
+-all: snowball libstemmer.o stemwords $(C_OTHER_SOURCES) $(C_OTHER_HEADERS) $(C_OTHER_OBJECTS)
++all: snowball libstemmer.o libstemmer.so stemwords $(C_OTHER_SOURCES) $(C_OTHER_HEADERS) $(C_OTHER_OBJECTS)
+ 
+ clean:
+ 	rm -f $(COMPILER_OBJECTS) $(RUNTIME_OBJECTS) \
+@@ -158,6 +158,9 @@ libstemmer/libstemmer.o: libstemmer/modules.h $(C_LIB_HEADERS)
+ libstemmer.o: libstemmer/libstemmer.o $(RUNTIME_OBJECTS) $(C_LIB_OBJECTS)
+ 	$(AR) -cru $@ $^
+ 
++libstemmer.so: libstemmer/libstemmer.o $(RUNTIME_OBJECTS) $(C_LIB_OBJECTS)
++	$(CC) $(CFLAGS) -shared $(LDFLAGS) -Wl,-soname,libstemmer.so.0,-version-script,libstemmer/symbol.map -o $@.0.0.0 $^
++
+ stemwords: $(STEMWORDS_OBJECTS) libstemmer.o
+ 	$(CC) -o $@ $^
+ 
+diff --git c/libstemmer/symbol.map i/libstemmer/symbol.map
+new file mode 100644
+index 0000000..7a3d423
+--- /dev/null
++++ i/libstemmer/symbol.map
+@@ -0,0 +1,6 @@
++SB_STEMMER_0 {
++    global:
++        sb_stemmer_*;
++    local:
++        *;
++};

--- a/experimental/flatpak/vte291-exceptions-gcc811.patch
+++ b/experimental/flatpak/vte291-exceptions-gcc811.patch
@@ -1,0 +1,61 @@
+From a13b07d346b280592510e7ee6af05bc602197691 Mon Sep 17 00:00:00 2001
+From: Debarshi Ray <debarshir@gnome.org>
+Date: Tue, 19 Jun 2018 18:28:25 +0200
+Subject: [PATCH] parser: Fix the build with GCC 8.1.1
+
+Otherwise it fails with:
+
+vteseq.cc:47:1: error: declaration of
+      'void vte::parser::Sequence::print() const' has a different
+      exception specifier
+    vte::parser::Sequence::print() const
+    ^~~
+  In file included from vteinternal.hh:30,
+                   from vteseq.cc:34:
+  parser-glue.hh:83:14: note: from previous declaration
+      'void vte::parser::Sequence::print() const noexcept'
+           void print() const noexcept;
+                ^~~~~
+
+... and so on.
+
+Fixes GNOME/vte#5:
+https://gitlab.gnome.org/GNOME/vte/issues/5
+---
+ src/vteseq.cc | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/vteseq.cc b/src/vteseq.cc
+index ba97480c..98f71b87 100644
+--- a/src/vteseq.cc
++++ b/src/vteseq.cc
+@@ -44,7 +44,7 @@
+ using namespace std::literals;
+ 
+ void
+-vte::parser::Sequence::print() const
++vte::parser::Sequence::print() const noexcept
+ {
+ #ifdef VTE_DEBUG
+         auto c = m_seq != nullptr ? terminator() : 0;
+@@ -145,7 +145,7 @@ vte_unichar_strlen(gunichar const* c)
+  */
+ char*
+ vte::parser::Sequence::ucs4_to_utf8(gunichar const* str,
+-                                    ssize_t len) const
++                                    ssize_t len) const noexcept
+ {
+         if (len < 0)
+                 len = vte_unichar_strlen(str);
+@@ -1406,7 +1406,7 @@ VteTerminalPrivate::set_color_index(vte::parser::Sequence const& seq,
+                                     int number,
+                                     int index,
+                                     int index_fallback,
+-                                    int osc)
++                                    int osc) noexcept
+ {
+         auto const str = *token;
+ 
+-- 
+GitLab
+


### PR DESCRIPTION
Use the ldc and dmd extensions, rather than bootstrapping them. Update
the GNOME runtime to the (old and unsupported) 3.34, which is built on
the freedesktop 19.08 SDK, which is the newest version with the ldc and
dmd extensions. Add the necessary dependencies to build appstream for
using appstreamcli.