### PR TITLE
Don't check GtkDragResult

### DIFF
--- a/source/gx/tilix/sidebar.d
+++ b/source/gx/tilix/sidebar.d
@@ -631,11 +631,9 @@ private:
     bool onRowDragFailed(DragContext dc, GtkDragResult dr, Widget widget) {
         trace("Drag Failed with ", dr);
         isRootWindow = false;
-        if (dr == GtkDragResult.NO_TARGET) {
-            //Only allow detach if whole hierarchy agrees (application, window, session)
-            if (sidebar.notifyIsActionAllowed(ActionType.DETACH_SESSION)) {
-                if (detachSessionOnDrop(dc)) return true;
-            }
+        //Only allow detach if whole hierarchy agrees (application, window, session)
+        if (sidebar.notifyIsActionAllowed(ActionType.DETACH_SESSION)) {
+            if (detachSessionOnDrop(dc)) return true;
         }
         return false;
     }

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -3270,11 +3270,9 @@ private:
                 dragImage = null;
             }
         }
-        if (dr == GtkDragResult.NO_TARGET) {
-            //Only allow detach if whole hierarchy agrees (application, window, session)
-            if (notifyIsActionAllowed(ActionType.DETACH_TERMINAL)) {
-                if (detachTerminalOnDrop(dc)) return true;
-            }
+        //Only allow detach if whole hierarchy agrees (application, window, session)
+        if (notifyIsActionAllowed(ActionType.DETACH_TERMINAL)) {
+            if (detachTerminalOnDrop(dc)) return true;
         }
         return false;
     }


### PR DESCRIPTION
Wayland does not set cancel reason thus this check always fails.

See: https://gitlab.gnome.org/GNOME/gtk/-/issues/2101