### PR TITLE
Don't add application/x-rootwindow-drop to dragSourceSet targets

### DIFF
--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -3166,10 +3166,7 @@ private:
         TargetEntry sessionEntry = new TargetEntry(SESSION_DND, TargetFlags.SAME_APP, DropTargets.SESSION);
         TargetEntry[] targets = [uriEntry, utf8TextEntry, stringEntry, textEntry, colorEntry, vteEntry, sessionEntry];
         vte.dragDestSet(DestDefaults.ALL, targets, DragAction.COPY | DragAction.MOVE);
-
-        // This is required to be able to drop on root window in Wayland, see gtknotebook.c
-        TargetEntry rootEntry = new TargetEntry("application/x-rootwindow-drop", 0, 0);
-        dragSourceSet(ModifierType.BUTTON1_MASK, [vteEntry, rootEntry], DragAction.MOVE);
+        dragSourceSet(ModifierType.BUTTON1_MASK, [vteEntry], DragAction.MOVE);
 
         //Title bar events
         addOnDragBegin(&onTitleDragBegin);


### PR DESCRIPTION
When running under Wayland if we add application/x-rootwindow-drop to
dragSourceSet targets then we end up getting spammed with endless calls
onTitleDragDataGet() when we drag and drop title onto root window.

Also it seems like sidebar never added application/x-rootwindow-drop to
its dragSourceSet targets so I suppose this is fine.

This change along with #2062 fixes an issue described here: #1906