### PR TITLE
Unbreak build with Meson 0.61.0

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -11,7 +11,6 @@ install_data(
 
 # Install the desktop file
 desktop_file = i18n.merge_file(
-    '@0@.desktop'.format(project_id),
     output: '@BASENAME@',
     input: 'pkg/desktop/@0@.desktop.in'.format(project_id),
     po_dir: meson.source_root() / 'po',
@@ -44,7 +43,6 @@ metainfo_with_releases = custom_target('metainfo-news-merge',
 
 # Install the MetaInfo file
 metainfo_file = i18n.merge_file(
-    tilix_metainfo_name,
     output: tilix_metainfo_name,
     input: metainfo_with_releases,
     po_dir: meson.source_root() / 'po',


### PR DESCRIPTION
See https://github.com/mesonbuild/meson/issues/9441. Fixes https://github.com/gnunn1/tilix/issues/2061. Tested via 1.9.4 [downstream](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=260943).
```
$ meson setup _build
[...]
data/meson.build:13:0: ERROR: Function does not take positional arguments.
```
http://www.ipv6proxy.net/go.php?u=http://package18.nyi.freebsd.org/data/122amd64-default-foo/2022-01-20_18h39m40s/logs/errors/tilix-1.9.4.log