### PR TITLE
Update to GtkD 3.10.0

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,10 +7,10 @@
     "dflags-ldc": ["-disable-linker-strip-dead","-link-defaultlib-shared=false"],
     "dependencies": {
         "gtk-d:gtkd": {
-            "version": "3.9.0"
+            "version": "3.10.0"
         },
         "gtk-d:vte": {
-            "version": "3.9.0"
+            "version": "3.10.0"
         }
     },
     "buildTypes": {

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,6 +1,6 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"gtk-d": "3.9.0"
+		"gtk-d": "3.10.0"
 	}
 }


### PR DESCRIPTION
I currently have a problem with building dmd on NixOS, so wasn't able to test it with dmd.

But building with ldc works fine.

The CI/CD should be running, though.