### PR TITLE
bugfix: fix std.xml deprecation warning

### DIFF
--- a/.github/ci/install-deps-deb.sh
+++ b/.github/ci/install-deps-deb.sh
@@ -28,4 +28,5 @@ eatmydata apt-get install -yq \
         libsecret-1-dev \
         libunwind-dev \
         libvted-3-dev \
+        libundead0 \
         po4a

--- a/dub.json
+++ b/dub.json
@@ -11,6 +11,9 @@
         },
         "gtk-d:vte": {
             "version": "3.9.0"
+        },
+        "undead": {
+            "version": "1.1.7"
         }
     },
     "buildTypes": {

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,6 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"gtk-d": "3.9.0"
+		"gtk-d": "3.9.0",
+		"undead": "1.1.7"
 	}
 }

--- a/meson.build
+++ b/meson.build
@@ -101,6 +101,7 @@ vted_dep = dependency('vted-3', version: '>=3.8.5')
 xlib_dep = dependency('x11')
 libunwind_dep = dependency('libunwind')
 libsecret_dep = dependency('libsecret-1', required: false)
+undead_dep = dependency('libundead0', version: '>=1.0.9')
 
 subdir('po')
 subdir('data')
@@ -113,7 +114,8 @@ executable('tilix',
                     vted_dep,
                     xlib_dep,
                     libunwind_dep,
-                    libsecret_dep],
+                    libsecret_dep,
+                    undead_dep],
     d_args: d_extra_args,
     d_module_versions: ['StdLoggerDisableTrace'],
     link_args: d_link_args,

--- a/source/gx/tilix/prefeditor/prefdialog.d
+++ b/source/gx/tilix/prefeditor/prefdialog.d
@@ -957,7 +957,7 @@ private:
             return;
         }
 
-        import std.xml: DocumentParser, ElementParser, Element, XMLException;
+        import undead.xml: DocumentParser, ElementParser, Element, XMLException;
 
         try {
             DocumentParser parser = new DocumentParser(ui);


### PR DESCRIPTION
Fixing the only warning I see:

```
source/gx/tilix/prefeditor/prefdialog.d(960,16): Deprecation: module `std.xml` is deprecated - Will be removed from Phobos in 2.101.0. If you still need it, go to https://github.com/DigitalMars/undeaD
```

Everything seems to be the same other than that.