### PR TITLE
nautilus: Add compatibility with Nautilus 43

### DIFF
--- a/data/nautilus/open-tilix.py
+++ b/data/nautilus/open-tilix.py
@@ -14,7 +14,6 @@ except ImportError:
 
 from gi import require_version
 require_version('Gtk', '3.0')
-require_version('Nautilus', '3.0')
 from gi.repository import Gio, GObject, Gtk, Nautilus
 
 

--- a/data/nautilus/open-tilix.py
+++ b/data/nautilus/open-tilix.py
@@ -12,9 +12,11 @@ except ImportError:
     from urllib.parse import unquote, urlparse
 
 
+from gi.repository import Gio, GObject, Nautilus
 from gi import require_version
-require_version('Gtk', '3.0')
-from gi.repository import Gio, GObject, Gtk, Nautilus
+if hasattr(Nautilus, "LocationWidgetProvider"):
+    require_version('Gtk', '3.0')
+    from gi.repository import Gtk
 
 
 TERMINAL = "tilix"
@@ -34,43 +36,44 @@ def open_terminal_in_file(filename):
     else:
         call("{0} &".format(TERMINAL), shell=True)
 
+# Nautilus 43 doesn't offer the LocationWidgetProvider any more
+if hasattr(Nautilus, "LocationWidgetProvider"):
+    class OpenTilixShortcutProvider(GObject.GObject,
+                                    Nautilus.LocationWidgetProvider):
 
-class OpenTilixShortcutProvider(GObject.GObject,
-                                Nautilus.LocationWidgetProvider):
+        def __init__(self):
+            source = Gio.SettingsSchemaSource.get_default()
+            if source.lookup(TILIX_KEYBINDINGS, True):
+                self._gsettings = Gio.Settings.new(TILIX_KEYBINDINGS)
+                self._gsettings.connect("changed", self._bind_shortcut)
+                self._create_accel_group()
+            self._window = None
+            self._uri = None
 
-    def __init__(self):
-        source = Gio.SettingsSchemaSource.get_default()
-        if source.lookup(TILIX_KEYBINDINGS, True):
-            self._gsettings = Gio.Settings.new(TILIX_KEYBINDINGS)
-            self._gsettings.connect("changed", self._bind_shortcut)
-            self._create_accel_group()
-        self._window = None
-        self._uri = None
+        def _create_accel_group(self):
+            self._accel_group = Gtk.AccelGroup()
+            shortcut = self._gsettings.get_string(GSETTINGS_OPEN_TERMINAL)
+            key, mod = Gtk.accelerator_parse(shortcut)
+            self._accel_group.connect(key, mod, Gtk.AccelFlags.VISIBLE,
+                                      self._open_terminal)
 
-    def _create_accel_group(self):
-        self._accel_group = Gtk.AccelGroup()
-        shortcut = self._gsettings.get_string(GSETTINGS_OPEN_TERMINAL)
-        key, mod = Gtk.accelerator_parse(shortcut)
-        self._accel_group.connect(key, mod, Gtk.AccelFlags.VISIBLE,
-                                  self._open_terminal)
+        def _bind_shortcut(self, gsettings, key):
+            if key == GSETTINGS_OPEN_TERMINAL:
+                self._accel_group.disconnect(self._open_terminal)
+                self._create_accel_group()
 
-    def _bind_shortcut(self, gsettings, key):
-        if key == GSETTINGS_OPEN_TERMINAL:
-            self._accel_group.disconnect(self._open_terminal)
-            self._create_accel_group()
+        def _open_terminal(self, *args):
+            filename = unquote(self._uri[7:])
+            open_terminal_in_file(filename)
 
-    def _open_terminal(self, *args):
-        filename = unquote(self._uri[7:])
-        open_terminal_in_file(filename)
-
-    def get_widget(self, uri, window):
-        self._uri = uri
-        if self._window:
-            self._window.remove_accel_group(self._accel_group)
-        if self._gsettings:
-            window.add_accel_group(self._accel_group)
-        self._window = window
-        return None
+        def get_widget(self, uri, window):
+            self._uri = uri
+            if self._window:
+                self._window.remove_accel_group(self._accel_group)
+            if self._gsettings:
+                window.add_accel_group(self._accel_group)
+            self._window = window
+            return None
 
 
 class OpenTilixExtension(GObject.GObject, Nautilus.MenuProvider):
@@ -99,7 +102,8 @@ class OpenTilixExtension(GObject.GObject, Nautilus.MenuProvider):
     def _menu_background_activate_cb(self, menu, file_):
         self._open_terminal(file_)
 
-    def get_file_items(self, window, files):
+    def get_file_items(self, *args):
+        files = args[-1]
         if len(files) != 1:
             return
         items = []
@@ -124,7 +128,8 @@ class OpenTilixExtension(GObject.GObject, Nautilus.MenuProvider):
 
         return items
 
-    def get_background_items(self, window, file_):
+    def get_background_items(self, *args):
+        file_ = args[-1]
         items = []
         if file_.get_uri_scheme() in REMOTE_URI_SCHEME:
             item = Nautilus.MenuItem(name='NautilusPython::open_bg_remote_item',


### PR DESCRIPTION
Nautilus 43 and nautlius-python 4 introduce major changes to the extension API. (Nautilus 43 also was ported to GTK4.)

The GNOME 43 Release Candidate is being released in the [next few days](https://wiki.gnome.org/FortyThree) and the stable release will happen on September 21.

I guess this merge proposals breaks the keyboard shortcut for Nautilus > Open in Tilix. (By the way, Ubuntu Desktop uses Ctrl+Alt+T for their systemwide Launch a Terminal feature.)