### PR TITLE
feat: add github dark theme

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -79,6 +79,7 @@ install_data(
 install_data(
     [
         'schemes/base16-twilight-dark.json',
+        'schemes/github-dark.json'
         'schemes/linux.json',
         'schemes/material.json',
         'schemes/monokai.json',

--- a/data/schemes/github-dark.json
+++ b/data/schemes/github-dark.json
@@ -1,0 +1,25 @@
+{
+    "name": "GitHub Dark",
+    "comment": "Ported for Terminix Colour Scheme",
+    "use-theme-colors": false,
+    "foreground-color": "#D1D5DA",
+    "background-color": "#1F2328",
+    "palette": [
+        "#586069",
+        "#EA495A",
+        "#33D057",
+        "#FFEA7F",
+        "#2087FF",
+        "#B392F0",
+        "#39C5CF",
+        "#D1D5DA",
+        "#959DA5",
+        "#F97582",
+        "#85E89D",
+        "#FFEA7F",
+        "#79B7FF",
+        "#B392F0",
+        "#56D4DD",
+        "#FAFBFC"
+    ]
+}


### PR DESCRIPTION
Added the dark variant of the GitHub color scheme.

![image](https://user-images.githubusercontent.com/59823800/209696398-9a4450c8-a1df-4ae2-abeb-5f38584e95c0.png)
