### PR TITLE
fix(security): avoid shell injection in open-tilix plugin

### DIFF
--- a/data/nautilus/open-tilix.py
+++ b/data/nautilus/open-tilix.py
@@ -4,7 +4,9 @@
 # Shortcuts Provider was inspired by captain nemo extension
 
 from gettext import gettext, textdomain
-from subprocess import PIPE, call
+from subprocess import Popen
+import shutil
+import shlex
 try:
     from urllib import unquote
     from urlparse import urlparse
@@ -18,7 +20,7 @@ require_version('Nautilus', '3.0')
 from gi.repository import Gio, GObject, Gtk, Nautilus
 
 
-TERMINAL = "tilix"
+TERMINAL = shutil.which("tilix")
 TILIX_KEYBINDINGS = "com.gexperts.Tilix.Keybindings"
 GSETTINGS_OPEN_TERMINAL = "nautilus-open"
 REMOTE_URI_SCHEME = ['ftp', 'sftp']
@@ -31,9 +33,9 @@ def _checkdecode(s):
 
 def open_terminal_in_file(filename):
     if filename:
-        call('{0} -w "{1}" &'.format(TERMINAL, filename), shell=True)
+        Popen([TERMINAL, '-w', filename])
     else:
-        call("{0} &".format(TERMINAL), shell=True)
+        Popen([TERMINAL])
 
 
 class OpenTilixShortcutProvider(GObject.GObject,
@@ -87,9 +89,9 @@ class OpenTilixExtension(GObject.GObject, Nautilus.MenuProvider):
             if result.port:
                 value = "{0} -p {1}".format(value, result.port)
             if file_.is_directory():
-                value = '{0} cd "{1}" ; $SHELL'.format(value, result.path)
+                value = '{0} cd {1} ; $SHELL'.format(value, shlex.quote(result.path))
 
-            call('{0} -e "{1}" &'.format(TERMINAL, value), shell=True)
+            Popen([TERMINAL, '-e', value])
         else:
             filename = Gio.File.new_for_uri(file_.get_uri()).get_path()
             open_terminal_in_file(filename)


### PR DESCRIPTION
I first reported this issue in https://bugs.archlinux.org/task/77698.

Currently tilix's open-tilix plugin for nautilus uses `subprocess.call()` with `shell=True`. However it fails to sanitize input data (filename) correctly, thus causing possible shell injection when filename contains `"` or `` ` ``, etc.

This PR tries to solve this issue by using `subprocess.Popen()` and avoiding invoking shell:

- [`Popen constructor`](https://docs.python.org/3/library/subprocess.html#popen-constructor) recommends to use `shutil.which()` to get actual path of executable (requires Python 3.3+).
- For `REMOTE_URI_SCHEME` part, [subprocess security considerations](https://docs.python.org/3/library/subprocess.html#security-considerations) recommends to use `shlex.quote()` to escape path (also requires Python 3.3+, and it may still have security issue when the shell is not POSIX-compliant).