### PR TITLE
Fix compilation error due to std.xml deprecation

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -11,6 +11,9 @@
         },
         "gtk-d:vte": {
             "version": "3.9.0"
+        },
+        "undead": {
+            "version": "1.1.8"
         }
     },
     "buildTypes": {

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,6 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"gtk-d": "3.9.0"
+		"gtk-d": "3.9.0",
+		"undead": "1.1.8"
 	}
 }

--- a/source/gx/tilix/prefeditor/prefdialog.d
+++ b/source/gx/tilix/prefeditor/prefdialog.d
@@ -957,7 +957,7 @@ private:
             return;
         }
 
-        import std.xml: DocumentParser, ElementParser, Element, XMLException;
+        import undead.xml: DocumentParser, ElementParser, Element, XMLException;
 
         try {
             DocumentParser parser = new DocumentParser(ui);


### PR DESCRIPTION
std.xml has been deprecated [1] and removed [2] from the standard library, therefor compilation failed due to the missing package.

As a temporary fix, add the undeaD package and use the xml library from it for the time being.

Fix #2152

[1] https://dlang.org/changelog/2.092.0.html#deprecate-xml
[2] https://dlang.org/changelog/2.101.0.html#remove-std-xml