### PR TITLE
Add close button to search box

### DIFF
--- a/source/gx/tilix/terminal/search.d
+++ b/source/gx/tilix/terminal/search.d
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
  * distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
@@ -150,6 +150,16 @@ private:
         bButtons.add(btnPrevious);
 
         bSearch.add(bButtons);
+
+        Button btnClose = new Button("window-close-symbolic", IconSize.MENU);
+        btnClose.setTooltipText(_("Close search box"));
+        btnClose.setRelief(ReliefStyle.NONE);
+        btnClose.setFocusOnClick(true);
+        btnClose.addOnClicked(delegate(Button) {
+            setRevealChild(false);
+            vte.grabFocus();
+        });
+        bSearch.packEnd(btnClose, false, false, 0);
 
         Frame frame = new Frame(bSearch, null);
         frame.setShadowType(ShadowType.NONE);


### PR DESCRIPTION
This patch add a close button to the search box, adding to pressing `esc` while on the search box input and the toggle button on the Window, to close the Search box area.

Fixes #2131

![image](https://user-images.githubusercontent.com/34901/233830048-bc015bdb-7e24-41d5-afc9-0429df9f988a.png)
