### PR TITLE
Follow system color-scheme preference

### DIFF
--- a/source/gx/tilix/application.d
+++ b/source/gx/tilix/application.d
@@ -479,7 +479,7 @@ private:
         if (!themeCssProvider) {
             tracef("No specific CSS found %s", cssURI);
         }
-        onThemeChange.emit(theme);
+        onThemeChange.emit();
     }
 
     void onAppStartup(GApplication) {
@@ -587,6 +587,7 @@ private:
                 } else {
                     Settings.getDefault().setProperty(GTK_APP_PREFER_DARK_THEME, darkMode);
                 }
+                onThemeChange.emit();
                 clearBookmarkIconCache();
                 break;
             case SETTINGS_MENU_ACCELERATOR_KEY:
@@ -917,13 +918,11 @@ public:
 // Events
 public:
     /**
-    * Invoked when the GTK theme has changed. While things could
-    * listen to gtk.Settings.addOnNotify directly, because this is a
-    * long lived object and GtkD doesn't provide a way to remove
-    * listeners it will lead to memory leaks so we use this instead
-    *
-    * Params:
-    *   name = the name of the theme
+    * Invoked when the GTK theme or theme-variant has changed. While
+    * things could listen to gtk.Settings.addOnNotify directly,
+    * because this is a long lived object and GtkD doesn't provide a
+    * way to remove listeners it will lead to memory leaks so we use
+    * this instead
     */
-    GenericEvent!(string) onThemeChange;
+    GenericEvent!() onThemeChange;
 }

--- a/source/gx/tilix/preferences.d
+++ b/source/gx/tilix/preferences.d
@@ -23,6 +23,8 @@ import gx.tilix.constants;
 
 //Gnome Desktop Settings
 enum SETTINGS_DESKTOP_ID = "org.gnome.desktop.interface";
+enum SETTINGS_COLOR_SCHEME_KEY = "color-scheme";
+enum SETTINGS_COLOR_SCHEME_PREFER_DARK_VALUE = "prefer-dark";
 enum SETTINGS_MONOSPACE_FONT_KEY = "monospace-font-name";
 
 //Gnome Proxy Settings

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -3698,7 +3698,7 @@ private:
 
 // Theme changed
 private:
-    void onThemeChanged(string theme) {
+    void onThemeChanged() {
         //Get CSS Provider updated via preference
         applyPreference(SETTINGS_PROFILE_BG_COLOR_KEY);
     }


### PR DESCRIPTION
On recent GNOME releases, it is possible to set a system-wide light/dark mode preference. tilix does not update its `theme-variant` based on this value. ([summary](https://blogs.gnome.org/alexm/2021/10/04/dark-style-preference/))

The preference is set in `org.gnome.desktop.interface` `color-scheme` and may be set to `default` / `prefer-light` / `prefer-dark`.

This PR modifies the existing `theme-variant` functionality so that
1. if `SETTINGS_THEME_VARIANT_KEY` is set to `system` (_default_) and a `color-scheme` value is set then a dark variant is preferred if `prefer-dark` is set.
2. whenever the system setting changes the `them-variant` preference is reapplied
3. `onThemChanged()` is emitted for them-variant change so that terminal colors may be reapplied if `SETTINGS_PROFILE_USE_THEME_COLORS_KEY` is set.