### PR TITLE
Clarify tooltip of "reset to default" button for keyboard shortcuts

### DIFF
--- a/po/ak.po
+++ b/po/ak.po
@@ -1792,7 +1792,7 @@ msgid "Enable shortcuts"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/ar.po
+++ b/po/ar.po
@@ -1826,7 +1826,7 @@ msgid "Enable shortcuts"
 msgstr "فعّل الاختصارات"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "عيّن المبدئي"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/ar_MA.po
+++ b/po/ar_MA.po
@@ -1803,7 +1803,7 @@ msgid "Enable shortcuts"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/bg.po
+++ b/po/bg.po
@@ -1903,7 +1903,7 @@ msgid "Enable shortcuts"
 msgstr "Включване на клавишните комбинации"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/ca.po
+++ b/po/ca.po
@@ -1854,7 +1854,7 @@ msgid "Enable shortcuts"
 msgstr "Habilita les dreceres de teclat"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Estableix per defecte"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/cs.po
+++ b/po/cs.po
@@ -1827,7 +1827,7 @@ msgid "Enable shortcuts"
 msgstr "Používat zkratky"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Nastavit výchozí"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/de.po
+++ b/po/de.po
@@ -1854,7 +1854,7 @@ msgid "Enable shortcuts"
 msgstr "Tastenkombinationen aktivieren"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Standard setzen"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/el.po
+++ b/po/el.po
@@ -1844,7 +1844,7 @@ msgid "Enable shortcuts"
 msgstr "Ενεργοποίηση συντομεύσεων"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1828,7 +1828,7 @@ msgid "Enable shortcuts"
 msgstr "Enable shortcuts"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Set default"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/eo.po
+++ b/po/eo.po
@@ -1834,7 +1834,7 @@ msgid "Enable shortcuts"
 msgstr "Ŝalti fulmoklavojn"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Uzi kiel impliciton"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/es.po
+++ b/po/es.po
@@ -1856,7 +1856,7 @@ msgid "Enable shortcuts"
 msgstr "Activar atajos de teclado"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Predeterminar"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/eu.po
+++ b/po/eu.po
@@ -1794,7 +1794,7 @@ msgid "Enable shortcuts"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/fi.po
+++ b/po/fi.po
@@ -1824,7 +1824,7 @@ msgid "Enable shortcuts"
 msgstr "Käytä pikanäppäimiä"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Aseta oletukseksi"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/fr.po
+++ b/po/fr.po
@@ -1870,7 +1870,7 @@ msgid "Enable shortcuts"
 msgstr "Activer les raccourcis"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Définir la valeur par défaut"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/gl.po
+++ b/po/gl.po
@@ -1795,7 +1795,7 @@ msgid "Enable shortcuts"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/he.po
+++ b/po/he.po
@@ -1816,7 +1816,7 @@ msgid "Enable shortcuts"
 msgstr "הפעלת קיצורים"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "הגדרה כבררת מחדל"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/hr.po
+++ b/po/hr.po
@@ -1843,7 +1843,7 @@ msgid "Enable shortcuts"
 msgstr "Aktiviraj prečace"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Postavi standardni"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/hu.po
+++ b/po/hu.po
@@ -1801,7 +1801,7 @@ msgid "Enable shortcuts"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/id.po
+++ b/po/id.po
@@ -1819,7 +1819,7 @@ msgid "Enable shortcuts"
 msgstr "Aktifkan pintasan"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Jadikan baku"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/is.po
+++ b/po/is.po
@@ -1177,7 +1177,7 @@ msgid "Enable shortcuts"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/it.po
+++ b/po/it.po
@@ -1858,7 +1858,7 @@ msgid "Enable shortcuts"
 msgstr "Abilita le scorciatoie da tastiera"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Imposta predefinito"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/ja.po
+++ b/po/ja.po
@@ -1811,7 +1811,7 @@ msgid "Enable shortcuts"
 msgstr "ショートカットを有効にする"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "デフォルトに設定"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/ko.po
+++ b/po/ko.po
@@ -1823,7 +1823,7 @@ msgid "Enable shortcuts"
 msgstr "바로 가기 활성화"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "기본값으로 설정"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/lt.po
+++ b/po/lt.po
@@ -1798,7 +1798,7 @@ msgid "Enable shortcuts"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/mr.po
+++ b/po/mr.po
@@ -1788,7 +1788,7 @@ msgid "Enable shortcuts"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -1804,7 +1804,7 @@ msgid "Enable shortcuts"
 msgstr "Skru på snarveier"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Sett som forvalg"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/ne.po
+++ b/po/ne.po
@@ -1178,7 +1178,7 @@ msgid "Enable shortcuts"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/nl.po
+++ b/po/nl.po
@@ -1861,7 +1861,7 @@ msgid "Enable shortcuts"
 msgstr "Sneltoetsen inschakelen"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Als standaard instellen"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/oc.po
+++ b/po/oc.po
@@ -1795,7 +1795,7 @@ msgid "Enable shortcuts"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Definir per defaut"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/pl.po
+++ b/po/pl.po
@@ -1823,7 +1823,7 @@ msgid "Enable shortcuts"
 msgstr "Włączenie skrótów klawiszowych"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Przywraca domyślny"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1860,7 +1860,7 @@ msgid "Enable shortcuts"
 msgstr "Habilitar atalhos"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Restaurar atalho padrão"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -1850,7 +1850,7 @@ msgid "Enable shortcuts"
 msgstr "Ativar atalhos do teclado"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Restaurar atalho padrão"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/ro.po
+++ b/po/ro.po
@@ -1834,7 +1834,7 @@ msgid "Enable shortcuts"
 msgstr "Activează prescurtări"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Setează ca implicit"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/ru.po
+++ b/po/ru.po
@@ -1851,7 +1851,7 @@ msgid "Enable shortcuts"
 msgstr "Включить комбинации клавиш"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Установить по умолчанию"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/sr.po
+++ b/po/sr.po
@@ -1835,7 +1835,7 @@ msgid "Enable shortcuts"
 msgstr "Омогући пречице"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Подеси подразумевано"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/sv.po
+++ b/po/sv.po
@@ -1838,7 +1838,7 @@ msgid "Enable shortcuts"
 msgstr "Aktivera genvägar"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Välj utgångsvärde"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/tilix.pot
+++ b/po/tilix.pot
@@ -1175,7 +1175,7 @@ msgid "Enable shortcuts"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/tr.po
+++ b/po/tr.po
@@ -1838,7 +1838,7 @@ msgid "Enable shortcuts"
 msgstr "Kısa yolları etkinleştir"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Öntanımlı değeri ayarla"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/uk.po
+++ b/po/uk.po
@@ -1837,7 +1837,7 @@ msgid "Enable shortcuts"
 msgstr "Увімкнути скорочення"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "Встановити типовим"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/vi.po
+++ b/po/vi.po
@@ -1793,7 +1793,7 @@ msgid "Enable shortcuts"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr ""
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1830,7 +1830,7 @@ msgid "Enable shortcuts"
 msgstr "启用快捷键"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "设为默认值"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1835,7 +1835,7 @@ msgstr "快捷鍵"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:805
 #, fuzzy
-msgid "Set default"
+msgid "Restore default shortcut for this action"
 msgstr "儲存為預設"
 
 #: source/gx/tilix/prefeditor/prefdialog.d:916

--- a/source/gx/tilix/prefeditor/prefdialog.d
+++ b/source/gx/tilix/prefeditor/prefdialog.d
@@ -802,7 +802,7 @@ private:
         bh.bind(SETTINGS_ACCELERATORS_ENABLED, cbAccelerators, "active", GSettingsBindFlags.DEFAULT);
 
         btnDefault = new Button("edit-undo-symbolic", IconSize.BUTTON);
-        btnDefault.setTooltipText(_("Set default"));
+        btnDefault.setTooltipText(_("Restore default shortcut for this action"));
         btnDefault.setSensitive(false);
         btnDefault.addOnClicked(delegate(Button) {
             TreeIter iter = tvShortcuts.getSelectedIter();
@@ -811,9 +811,9 @@ private:
             size_t length;
             string defaultValue;
             if (filter.getValueString(iter, COLUMN_SHORTCUT_TYPE) == SC_TYPE_ACTION) {
-              defaultValue = gsShortcuts.getDefaultValue(action).getString(length);
+                defaultValue = gsShortcuts.getDefaultValue(action).getString(length);
             } else {
-              defaultValue = SHORTCUT_DISABLED;
+                defaultValue = SHORTCUT_DISABLED;
             }
             filter.convertIterToChildIter(iter, iter);
             if (defaultValue == SHORTCUT_DISABLED) {


### PR DESCRIPTION
This prevents ambiguity about whether the reset applies to the current shortcut or to all shortcuts
