### PR TITLE
Fix markup error of lblTitle

### DIFF
--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -1274,7 +1274,7 @@ private:
         string title = _overrideTitle.length == 0 ? gsProfile.getString(SETTINGS_PROFILE_TITLE_KEY) : _overrideTitle;
         title = getDisplayText(title);
         if (title != lastTitle) {
-            lblTitle.setMarkup(title);
+            lblTitle.setText(title);
             lastTitle = title;
         }
         // Need to always emit title since other titles could be tracking variables that terminal isn't


### PR DESCRIPTION
Recently when auditing my laptop's log, I found that sometimes tilix outputs errors like this:

```
Jan 14 19:16:46 hostname tilix[602551]: Failed to set text '1: sleep 10 && ls ~' from markup due to error parsing markup: Error on line 1: Entity did not end with a semicolon; most likely you used an ampersand character without intending to start an entity — escape ampersand as &amp;
```

This could be easily reproduced:

```
> tilix --new-process
```

And then in the new tilix window:

```
> sleep 10 && ls
```

And you could get this Gtk warning (The GtkLabel inside the GtkBox is also not updated). This PR simply uses `setText` instead of `setMarkup`, as it seems that no pango markup is actually used here.