### PR TITLE
Remove duplicate package in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,7 @@ COMMANDS="install glib-compile-schemas glib-compile-resources msgfmt desktop-fil
 if [ "$PREFIX" = '/usr' ] || [ "$PREFIX" = "/usr/local" ]; then
     COMMANDS="$COMMANDS xdg-desktop-menu"
 fi
-PACKAGES="coreutils glib2 glib2 gettext desktop-file-utils gtk-update-icon-cache xdg-utils"
+PACKAGES="coreutils glib2 gettext desktop-file-utils gtk-update-icon-cache xdg-utils"
 i=0
 for COMMAND in $COMMANDS; do
     type $COMMAND >/dev/null 2>&1 || {


### PR DESCRIPTION
Removes a duplicate `glib2` from `$PACKAGES`