### PR TITLE
CI: use debian bookworm

### DIFF
--- a/.github/ci/Dockerfile-debian-bookworm
+++ b/.github/ci/Dockerfile-debian-bookworm
@@ -1,7 +1,7 @@
 #
 # Docker file for Tilix CI tests on Debian Testing
 #
-FROM debian:testing
+FROM debian:bookworm
 
 # prepare
 RUN mkdir -p /build/ci/

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,14 +46,14 @@ jobs:
       run: dub test --compiler=$DC
 
 
-  build-debian-testing:
-    name: Debian Testing
+  build-debian-bookworm:
+    name: Debian Bookworm
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 
     - name: Create Build Environment
-      run: cd .github/ci/ && podman build -t tilix -f ./Dockerfile-debian-testing .
+      run: cd .github/ci/ && podman build -t tilix -f ./Dockerfile-debian-bookworm .
 
     - name: Build
       run: podman run -t -e COMPILER_VENDOR=$CVENDOR -e CC=gcc -e CXX=g++ -v `pwd`:/build tilix


### PR DESCRIPTION
libgtkd-3-0 package in debian trixie depends on libphobos2-ldc-shared105 and CI is failing, so uses debian bookworm.