### PR TITLE
Add "terminal" to application keywords

### DIFF
--- a/data/pkg/desktop/com.gexperts.Tilix.desktop.in
+++ b/data/pkg/desktop/com.gexperts.Tilix.desktop.in
@@ -2,7 +2,7 @@
 Version=1.0
 Name=Tilix
 Comment=A tiling terminal for GNOME
-Keywords=shell;prompt;command;commandline;cmd;
+Keywords=shell;prompt;command;commandline;cmd;terminal;
 Exec=tilix
 Terminal=false
 Type=Application


### PR DESCRIPTION
Although the word terminal is in the description, search methods such as Gnome's application search won't show up Tilix if you search for "term" "terminal" or any partial matches. Adding "terminal" to the application keywords fixes this.