### PR TITLE
Convert CTRL+Backspace to CTRL+H/CTRL+W/CTRL+?/EscSeq/...

### DIFF
--- a/data/gsettings/com.gexperts.Tilix.gschema.xml
+++ b/data/gsettings/com.gexperts.Tilix.gschema.xml
@@ -112,6 +112,17 @@
     <value nick='tty' value='4'/>
   </enum>
 
+  <enum id='com.gexperts.Tilix.EraseControl'>
+    <value nick='none' value='0'/>
+    <value nick='control-h' value='1'/>
+    <value nick='control-w' value='2'/>
+    <value nick='control-?' value='3'/>
+    <value nick='ascii-backspace' value='4'/>
+    <value nick='ascii-delete' value='5'/>
+    <value nick='delete-sequence' value='6'/>
+    <value nick='tty' value='7'/>
+  </enum>
+
   <enum id='com.gexperts.Tilix.ExitAction'>
     <value nick='close' value='0'/>
     <value nick='restart' value='1'/>
@@ -748,6 +759,10 @@
     <key name="cjk-utf8-ambiguous-width" enum="com.gexperts.Tilix.CJKWidth">
       <default>'narrow'</default>
       <summary>Whether ambiguous-width characters are narrow or wide when using UTF-8 encoding</summary>
+    </key>
+    <key name="ctrl-backspace" enum="com.gexperts.Tilix.EraseControl">
+      <default>'none'</default>
+      <summary>Makes the terminal threat "Control+Backspace" as different control instead of "Backspace". May be used as a shortcut for removing deleting a word instead of a character.</summary>
     </key>
     <!-- Terminal Title -->
     <key name="terminal-title" type="s">

--- a/source/gx/tilix/prefeditor/profileeditor.d
+++ b/source/gx/tilix/prefeditor/profileeditor.d
@@ -1084,6 +1084,14 @@ private:
         grid.attach(cbDelete, 1, row, 1, 1);
         row++;
 
+        Label lblCtrlBs = new Label(_("Ctrl+Backspace key generates"));
+        lblCtrlBs.setHalign(Align.END);
+        grid.attach(lblCtrlBs, 0, row, 1, 1);
+        ComboBox cbCtrlBackspace = createNameValueCombo([_("Default"), _("Control-W"), _("Control-H"), _("Control-?"), _("ASCII DEL"), _("Escape sequence"), _("TTY")], SETTINGS_PROFILE_CTRL_BACKSPACE_VALUES);
+        bh.bind(SETTINGS_PROFILE_CTRL_BACKSPACE_KEY, cbCtrlBackspace, "active-id", GSettingsBindFlags.DEFAULT);
+        grid.attach(cbCtrlBackspace, 1, row, 1, 1);
+        row++;
+
         Label lblEncoding = new Label(_("Encoding"));
         lblEncoding.setHalign(Align.END);
         grid.attach(lblEncoding, 0, row, 1, 1);

--- a/source/gx/tilix/preferences.d
+++ b/source/gx/tilix/preferences.d
@@ -219,6 +219,8 @@ enum SETTINGS_PROFILE_DELETE_BINDING_KEY = "delete-binding";
 enum SETTINGS_PROFILE_ENCODING_KEY = "encoding";
 enum SETTINGS_PROFILE_CJK_WIDTH_KEY = "cjk-utf8-ambiguous-width";
 immutable string[] SETTINGS_PROFILE_CJK_WIDTH_VALUES = ["narrow", "wide"];
+enum SETTINGS_PROFILE_CTRL_BACKSPACE_KEY = "ctrl-backspace";
+immutable string[] SETTINGS_PROFILE_CTRL_BACKSPACE_VALUES = ["none", "control-w", "control-h", "control-?", "ascii-delete", "delete-sequence", "tty"];
 
 enum SETTINGS_PROFILE_EXIT_ACTION_KEY = "exit-action";
 enum SETTINGS_PROFILE_EXIT_ACTION_CLOSE_VALUE = "close";

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -1044,6 +1044,34 @@ private:
         vteHandlers ~= vte.addOnKeyPress(delegate(Event event, Widget widget) {
             if (vte is null) return false;
 
+            // If control-backspace is registered, convert it to control-*, which is
+            // used interchangeably in some terminal emulators,
+            // often for removing a word instead of a character.
+            if (gsProfile.getString(SETTINGS_PROFILE_CTRL_BACKSPACE_KEY) != SETTINGS_PROFILE_CTRL_BACKSPACE_VALUES[0] && (event.key.keyval == GdkKeysyms.GDK_BackSpace) && (event.key.state & ModifierType.CONTROL_MASK)) {
+                switch (gsProfile.getString(SETTINGS_PROFILE_CTRL_BACKSPACE_KEY)) {
+                    case SETTINGS_PROFILE_CTRL_BACKSPACE_VALUES[1]: // ^w
+                        vte.feedChild("\u0017");
+                        return true;
+                    case SETTINGS_PROFILE_CTRL_BACKSPACE_VALUES[2]: // ^h
+                        vte.feedChild("\u0008");
+                        return true;
+                    case SETTINGS_PROFILE_CTRL_BACKSPACE_VALUES[3]: // ^?
+                        vte.feedChild("\u001F");
+                        return true;
+                    case SETTINGS_PROFILE_CTRL_BACKSPACE_VALUES[4]: // DEL
+                        vte.feedChild("\u0007");
+                        return true;
+                    case SETTINGS_PROFILE_CTRL_BACKSPACE_VALUES[5]: // ESC [ 3 ~
+                        vte.feedChild("\u001B\u005B\u0033\u007E");
+                        return true;
+                    case SETTINGS_PROFILE_CTRL_BACKSPACE_VALUES[6]: // DEL
+                        vte.feedChild("\u007F");
+                        return true;
+                    default:
+                        break;
+                }
+            }
+
             if (event.key.keyval == GdkKeysyms.GDK_Return && checkVTEFeature(TerminalFeature.EVENT_SCREEN_CHANGED) && currentScreen == TerminalScreen.NORMAL) {
                 glong row, column;
                 vte.getCursorPosition(column, row);
@@ -2491,6 +2519,7 @@ private:
             SETTINGS_PROFILE_BACKSPACE_BINDING_KEY,
             SETTINGS_PROFILE_DELETE_BINDING_KEY,
             SETTINGS_PROFILE_CJK_WIDTH_KEY, SETTINGS_PROFILE_ENCODING_KEY, SETTINGS_PROFILE_CURSOR_BLINK_MODE_KEY, //Only pass the one font key, will handle both cases
+            SETTINGS_PROFILE_CTRL_BACKSPACE_KEY,
             SETTINGS_PROFILE_FONT_KEY,
             SETTINGS_TERMINAL_TITLE_STYLE_KEY, SETTINGS_AUTO_HIDE_MOUSE_KEY,
             SETTINGS_PROFILE_USE_CURSOR_COLOR_KEY,


### PR DESCRIPTION
When you click CTRL+Backspace, terminal emulators sometimes send key-press to CTRL+H, CTRL+W, CTRL+?, Esc seq, TTY.

Default is set to "none", therefore using default VTE settings and nothing changes unless you manually change it. I recommend CTRL+W.

![image](https://github.com/user-attachments/assets/fb0ad913-8abc-4359-bab6-c5574b1faef2)

#1348 #1498 :tada: