### PR TITLE
Clear output action

### DIFF
--- a/data/gsettings/com.gexperts.Tilix.gschema.xml
+++ b/data/gsettings/com.gexperts.Tilix.gschema.xml
@@ -1201,6 +1201,10 @@
       <default>'disabled'</default>
       <summary>Keyboard shortcut to unselect all text in terminal</summary>
     </key>
+    <key name="terminal-clear" type="s">
+      <default>'disabled'</default>
+      <summary>Keyboard shortcut to clear the output buffer, excluding the last line, similar to how 'clear' works in a shell</summary>
+    </key>
     <key name="terminal-zoom-in" type="s">
       <default>'&lt;Ctrl&gt;plus'</default>
       <summary>Keyboard shortcut to make font larger</summary>

--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -437,6 +437,12 @@
                 <property name="title" translatable="yes" context="shortcut window">Unselect all</property>
               </object>
             </child>
+            <child>
+              <object class="GtkShortcutsShortcut" id ="terminal-clear">
+                <property name="visible">1</property>
+                <property name="title" translatable="yes" context="shortcut window">Clear output</property>
+              </object>
+            </child>
           </object>
         </child>
         <child>

--- a/source/gx/tilix/terminal/actions.d
+++ b/source/gx/tilix/terminal/actions.d
@@ -26,6 +26,7 @@ enum ACTION_COPY_LINK = "copy-link";
 enum ACTION_OPEN_LINK = "open-link";
 enum ACTION_SELECT_ALL = "select-all";
 enum ACTION_UNSELECT_ALL = "unselect-all";
+enum ACTION_CLEAR = "clear";
 enum ACTION_ZOOM_IN = "zoom-in";
 enum ACTION_ZOOM_OUT = "zoom-out";
 enum ACTION_ZOOM_NORMAL = "zoom-normal";

--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -576,6 +576,21 @@ private:
 
         registerActionWithSettings(group, ACTION_PREFIX, ACTION_SELECT_ALL, gsShortcuts, delegate(GVariant, SimpleAction) { vte.selectAll(); });
         registerActionWithSettings(group, ACTION_PREFIX, ACTION_UNSELECT_ALL, gsShortcuts, delegate(GVariant, SimpleAction) { vte.unselectAll(); });
+        registerActionWithSettings(group, ACTION_PREFIX, ACTION_CLEAR, gsShortcuts, delegate(GVariant, SimpleAction) {
+            //Clear text while leaving current line intact, keeping selection and clearing scrollback buffer
+            long totalRows = vte.getRowCount();
+            string toFeed = "";
+            //Move down
+            foreach (i; 1 .. totalRows) toFeed ~= "\n";
+            //Clear scrollback buffer
+            toFeed ~= "\033[3J";
+            //Move cursor up
+            toFeed ~= format("\033[%dA", totalRows);
+            //Remove text below current line
+            toFeed ~= "\033[s\033[E\033[0J\033[u";
+            vte.reset(true, false);
+            vte.feed(toFeed);
+        });
 
         //Link Actions, no shortcuts, context menu only
         registerAction(group, ACTION_PREFIX, ACTION_COPY_LINK, null, delegate(GVariant, SimpleAction) {
@@ -1854,6 +1869,12 @@ private:
 
             mmContext.appendItem(clipItem);
         }
+        
+        //Section for screen actions (clearing output)
+        GMenu screenSection = new GMenu();
+        screenSection.append(_("Clear"), getActionDetailedName(ACTION_PREFIX, ACTION_CLEAR));
+        mmContext.appendSection(null, screenSection);
+
         //Check if titlebar is hidden and add extra items
         if (!bTitle.isVisible()) {
             GMenu windowSection = new GMenu();


### PR DESCRIPTION
Clear text while leaving current line intact, keeping selection and clearing scrollback buffer. Appears in shortcut list in `Terminal -> Clear output` and right-click menu as `Clear`.

Note: while this is a hacky method, it reproduces same "Clear" that vscode does, especially with TUI's.

#2217 :tada: