### PR TITLE
Properly encode pasted text containing newlines

### DIFF
--- a/source/gx/tilix/terminal/terminal.d
+++ b/source/gx/tilix/terminal/terminal.d
@@ -1447,7 +1447,7 @@ private:
         dialog.showAll();
         if (dialog.run() == ResponseType.APPLY) {
             pasteText = dialog.text;
-            vte.feedChild(pasteText[0 .. $]);
+            this.pasteText(pasteText[0 .. $]);
             if (gsProfile.getBoolean(SETTINGS_PROFILE_SCROLL_ON_INPUT_KEY)) {
                 scrollToBottom();
             }
@@ -1488,9 +1488,9 @@ private:
 
         if (gsSettings.getBoolean(SETTINGS_STRIP_FIRST_COMMENT_CHAR_ON_PASTE_KEY) && pasteText.length > 0 && (pasteText[0] == '#' || pasteText[0] == '$')) {
             pasteText = pasteText[1 .. $];
-            vte.feedChild(pasteText);
+            this.pasteText(pasteText);
         } else if (stripTrailingWhitespace) {
-            vte.feedChild(pasteText);
+            this.pasteText(pasteText);
         } else if (source == GDK_SELECTION_CLIPBOARD) {
             vte.pasteClipboard();
         } else {
@@ -2631,6 +2631,17 @@ private:
                 Signals.handlerUnblock(vte, _commitHandlerId);
             }
         }
+    }
+
+    void pasteText(string text) {
+        // It is better to use vte.pasteText(text), but a GtkD version that
+        // contains vte.pasteText(text) has not yet been released.  The current
+        // lateset version GtkD 3.10.0 does not have this interface.  We
+        // instead need to manually convert the newlines or implement the
+        // bracketed paste mode.  We use the simple newline conversion here.
+        // When the next version of GtkD is released, the following line should
+        // be replaced with "vte.pasteText(text);".
+        vte.feedChild(text.replace("\n", "\r"));
     }
 
     void showInfoBarMessage(string message) {


### PR DESCRIPTION
This fixes #1959.

I received a report in my project (https://github.com/akinomyoga/ble.sh/issues/544).

The problem is that Tilix currently sends the raw text to the terminal application with its advanced paste dialog. However, the data sent to the terminal application is not plain text but should properly be encoded following the convention of the terminal communication. In particular, the newlines should be encoded by `\x0D` (which has an equivalent byte representation as CR `\r` in an ASCII string) in the traditional terminal protocol because `\x0A` (which has the same byte representation as LF `\n` in an ASCII string) means <kbd>C-j</kbd> in the convention. If one wants to send the multiline text preserving the different variations of newlines, when the terminal application requests the bracketed paste mode, the terminal should use the bracketed-paste-mode beginning/ending markers of the pasted text. All these processing is supposed to be handled by vte's `vte_terminal_paste_text`, but Tilix currently uses `vte_terminal_feed_child` to directly send the raw pasted text.

The same problem has been reported in #1959 for nano.

Ideally, we should use `vte_terminal_paste_text` through GtkD's `Terminal::pasteText`. However, this interface of GtkD has not yet been released. In this PR, we instead convert the newlines manually. I have confirmed that both issues #1959 and https://github.com/akinomyoga/ble.sh/issues/544 are fixed with this change.
